### PR TITLE
Change API layering in spec

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -794,9 +794,9 @@ A signal base value is one of the following:
 : "<dfn export><code>highest-scoring-other-bid</code></dfn>"
 :: The bid value of the highest scoring bid that did not win.
 : "<dfn export><code>script-run-time</code></dfn>"
-:: The running time of the script in ms(?).
+:: The running time of the script in milliseconds.
 : "<dfn export><code>signals-fetch-time</code></dfn>"
-:: The time it took for the signals fetch to complete in ms(?)
+:: The time it took for the signals fetch to complete in milliseconds.
 : "<dfn export><code>bid-reject-reason</code></dfn>"
 :: The reason a bid was rejected.
 

--- a/spec.bs
+++ b/spec.bs
@@ -157,13 +157,30 @@ global scope.
 
 Additionally, each global scope should set the [=PrivateAggregation/get batching
 scope steps=] for the {{PrivateAggregation}} object it exposes to a non-null
-value. The global scope may wait to set the field to indicate that the API is
-not yet available, for example, during the initial execution of a script after
-loading. For any batching scope returned by the [=PrivateAggregation/get
-batching scope steps=], the [=mark a batching scope complete=] steps should
-later be performed given that same batching scope, the global scope's [=relevant
-settings object=]'s [=environment settings object/origin=] and some [=context
-type=].
+value. The global scope should wait to set the field until the API is intended
+to be available.
+
+<div class="example" id="shared-storage-only-within-operations">
+    Shared Storage only allows Private Aggregation when an operation is being
+    invoked, not in the top-level context:
+    <pre highlight="js">
+    class ExampleOperation {
+      async run(data) {
+        privateAggregation.contributeToHistogram(...)  // This is allowed.
+      }
+    }
+    register('example-operation', ExampleOperation);
+
+    privateAggregation.contributeToHistogram(...)  // This would cause an error.
+    </pre>
+    So, Shared Storage sets [=PrivateAggregation/get batching scope steps=]
+    after the initial execution of the module script is complete.
+</div>
+
+For any batching scope returned by the [=PrivateAggregation/get batching scope
+steps=], the [=mark a batching scope complete=] steps should later be performed
+given that same batching scope, the global scope's [=relevant settings
+object=]'s [=environment settings object/origin=] and some [=context type=].
 
 Note: This last requirement means that global scopes with different origins
     cannot share the same batching scope.

--- a/spec.bs
+++ b/spec.bs
@@ -133,6 +133,8 @@ are:
     [=PrivateAggregation/get batching scope steps=].
 1. If |batchingScopeSteps| is null, throw a new {{DOMException}} with name
     "`NotAllowedError`".
+    Note: This indicates the API is not yet available.
+
 1. Let |entry| be a new [=contribution cache entry=] with the items:
     : [=contribution cache entry/contribution=]
     :: |contribution|
@@ -144,7 +146,6 @@ are:
 Issue: Check that value can actually be zero in the spec pipeline.
 
 Issue(44): Consider accepting an array of contributions.
-
 
 Exposing to global scopes {#exposing}
 =====================================
@@ -604,8 +605,6 @@ When an operation invocation completes, [=mark a batching scope complete=] given
 the associated [=batching scope=], the global scope's [=relevant settings
 object=]'s [=environment settings object/origin=] and
 "<code>shared-storage</code>".
-
-Issue: How do we handle overrides without causing bikeshed errors?
 
 Protected Audience API monkeypatches {#protected-audience-api-monkeypatches}
 ============================================================================

--- a/spec.bs
+++ b/spec.bs
@@ -609,8 +609,8 @@ To <dfn>obtain a report's shared info</dfn> given an [=aggregatable report=]
 1. Return the result of [=serializing an infra value to a json string=] given
     |sharedInfo|.
 
-Shared Storage API monkeypatches {#shared-storage-api-monkeypatches}
-====================================================================
+Shared Storage API monkey patches {#shared-storage-api-monkey-patches}
+======================================================================
 
 Issue(43): This should be moved to the Shared Storage spec.
 
@@ -624,12 +624,12 @@ The {{WindowSharedStorage}}'s {{WindowSharedStorage/run()}} method steps are
 modified in two ways. First, add the following step in the nested scope just
 after "Let |operation| be |operationMap|[|name|]." (renumbering later steps as
 appropriate):
-<div algorithm="shared-storage-run-monkeypatch-1">
+<div algorithm="shared-storage-run-monkey-patch-1">
 2. Let <var ignore>batchingScope</var> be a new [=batching scope=].
 
 </div>
 Second, at the end of the same nested scope, add the following step:
-<div algorithm="shared-storage-run-monkeypatch-2">
+<div algorithm="shared-storage-run-monkey-patch-2">
 5. When the above [=call=] returns, [=process contributions for a batching
     scope=] given <var ignore>batchingScope</var>,
     <var ignore>outsideSettings</var>' [=environment settings object/origin=]
@@ -641,12 +641,12 @@ The {{WindowSharedStorage}}'s {{WindowSharedStorage/selectURL()}} method steps
 are modified in two ways. First, add the following step in the nested scope just
 after "Let |operation| be |operationMap|[|name|]." (renumbering later steps as
 appropriate):
-<div algorithm="shared-storage-selecturl-monkeypatch-1">
+<div algorithm="shared-storage-selecturl-monkey-patch-1">
 2. Let <var ignore>batchingScope</var> be a new [=batching scope=].
 
 </div>
 Second, at the end of the same nested scope, add the following step:
-<div algorithm="shared-storage-selecturl-monkeypatch-2">
+<div algorithm="shared-storage-selecturl-monkey-patch-2">
 8. [=Process contributions for a batching scope=] given
     <var ignore>batchingScope</var>, <var ignore>outsideSettings</var>'
     [=environment settings object/origin=] and "<code>shared-storage</code>".
@@ -654,13 +654,13 @@ Second, at the end of the same nested scope, add the following step:
 </div>
 
 Issue: Once <a href="https://github.com/wicg/shared-storage/issues/88">
-    shared-storage/88</a> is resolved, align the above monkeypatches with how
+    shared-storage/88</a> is resolved, align the above monkey patches with how
     `keepAlive` is handled at operation completion.
 
 The {{Worklet/addModule()}} steps are modified to add a new step just before
 the final step ("Return <var ignore>promise</var>."), renumbering the last step
 as appropriate:
-<div algorithm="shared-storage-addmodule-monkeypatch">
+<div algorithm="shared-storage-addmodule-monkey-patch">
 7. If |this| is a {{SharedStorageWorklet}}, [=upon fulfillment=] of |promise| or
     [=upon rejection=] of |promise|, run the following steps:
     1. Let |globalScopes| be |this|'s [=Worklet/global scopes=].
@@ -679,17 +679,17 @@ as appropriate:
 </div>
 
 Issue: Once <a href="https://github.com/wicg/shared-storage/issues/89">
-    shared-storage/89</a> is resolved, align the above monkeypatch with how
+    shared-storage/89</a> is resolved, align the above monkey patch with how
     access to `sharedStorage` is prevented in
     {{SharedStorageWorkletGlobalScope}}s until {{Worklet/addModule()}}'s initial
     execution is complete.
 
 Note: This extends Shared Storage's existing {{Worklet/addModule()}}
     <a href="https://wicg.github.io/shared-storage/#worklet-monkey-patch">
-    monkeypatch</a>.
+    monkey patch</a>.
 
-Protected Audience API monkeypatches {#protected-audience-api-monkeypatches}
-============================================================================
+Protected Audience API monkey patches {#protected-audience-api-monkey-patches}
+==============================================================================
 
 Issue(43): This should be moved to the Protected Audience spec, along with any
     other Protected Audience-specific details.
@@ -722,7 +722,7 @@ Issue: Do we want to align naming with implementation?
 The {{Navigator/runAdAuction()}} method steps are modified to add the following
 steps after step 6 ("Let <var ignore>p</var> be [=a new promise=]"), renumbering
 later steps as appropriate:
-<div algorithm="protected-audience-runadauction-monkeypatch">
+<div algorithm="protected-audience-runadauction-monkey-patch">
 7. Let |batchingScopeMap| be a new [=map/is empty|empty=] [=map=].
 1. [=list/iterate|For each=] |bidderOrigin| of |auctionConfig|'s
     <a spec="turtledove" for="auction config">interest group buyers</a>:
@@ -751,7 +751,7 @@ Issue: Need to handle `auctionReportBuyers` and `auctionReportBuyerKeys` here or
 The <a spec="turtledove">evaluate a script</a> steps are modified to add the
 following steps after step 11 ("If <var ignore>evaluationStatus</var> is an
 [=ECMAScript/abrupt completion=]..."), renumbering later steps as appropriate:
-<div algorithm="protected-audience-evaluate-a-script-monkeypatch">
+<div algorithm="protected-audience-evaluate-a-script-monkey-patch">
 12. Set <var ignore>global</var>'s {{InterestGroupScriptRunnerGlobalScope/
     privateAggregation}}'s [=PrivateAggregation/get batching scope steps=] to
     the following algorithm:
@@ -762,8 +762,8 @@ following steps after step 11 ("If <var ignore>evaluationStatus</var> is an
 </div>
 
 Issue: Once <a href="https://github.com/wicg/turtledove/issues/615">
-    protected-audience/615</a> is resolved, align the above monkeypatch with how
-    access to other functions is prevented in
+    protected-audience/615</a> is resolved, align the above monkey patch with
+    how access to other functions is prevented in
     {{InterestGroupScriptRunnerGlobalScope}}s until the script's initial
     execution is complete.
 

--- a/spec.bs
+++ b/spec.bs
@@ -137,7 +137,7 @@ are:
     "`NotAllowedError`".
 
     Note: This indicates the API is not yet available, for example, because the
-        the initial execution of the script after loading is not complete.
+        initial execution of the script after loading is not complete.
 
     Issue: Consider improving developer ergonomics here (e.g. a way to detect
         this case).
@@ -148,7 +148,8 @@ are:
     : [=contribution cache entry/batching scope=]
     :: The result of running |batchingScopeSteps|
 
-1. [=Append an entry to the contribution cache=] given |entry|.
+1. [=Append an entry to the contribution cache|Append=] |entry| to the
+    [=contribution cache=].
 
 Issue: Check that value can actually be zero in the spec pipeline.
 
@@ -157,9 +158,8 @@ Issue(44): Consider accepting an array of contributions.
 Exposing to global scopes {#exposing}
 =====================================
 
-To expose this API to a global scope, a readonly attribute of type
-{{PrivateAggregation}} named `privateAggregation` should be exposed on the
-global scope.
+To expose this API to a global scope, a readonly attribute `privateAggregation`
+of type {{PrivateAggregation}} should be exposed on the global scope.
 
 Additionally, each global scope should set the [=PrivateAggregation/get batching
 scope steps=] for the {{PrivateAggregation}} object it exposes to a non-null
@@ -184,12 +184,15 @@ to be available.
 </div>
 
 For any batching scope returned by the [=PrivateAggregation/get batching scope
-steps=], the [=mark a batching scope complete=] steps should later be performed
-given that same batching scope, the global scope's [=relevant settings
-object=]'s [=environment settings object/origin=] and some [=context type=].
+steps=], the [=process contributions for a batching scope=] steps should later
+be performed given that same batching scope, the global scope's [=relevant
+settings object=]'s [=environment settings object/origin=] and some [=context
+type=].
 
 Note: This last requirement means that global scopes with different origins
-    cannot share the same batching scope.
+    cannot share the same batching scope, see Same-origin policy discussion.
+
+    Issue: Link Same-origin policy section.
 
 Structures {#structures}
 ========================
@@ -276,27 +279,30 @@ possible decimal number.
 Issue: This would ideally be replaced by a more descriptive algorithm in Infra.
     See <a href="https://github.com/whatwg/infra/issues/201">infra/201</a>.
 
+Exported algorithms {#exported-algorithms}
+------------------------------------------
+
+Note: These algorithms allow other specifications can integrate with this API.
+
 To <dfn algorithm export>append an entry to the contribution cache</dfn> given a
 [=contribution cache entry=] |entry|:
 1. [=list/Append=] |entry| to the [=contribution cache=].
 
-To <dfn algorithm export>mark a batching scope complete</dfn> given a [=batching
-scope=] |batchingScope|, an [=origin=] |reportingOrigin| and a [=context type=]
-|contextType|:
+To <dfn algorithm export>process contributions for a batching scope</dfn> given
+a [=batching scope=] |batchingScope|, an [=origin=] |reportingOrigin| and a
+[=context type=] |contextType|:
 1. Let |batchEntries| be a new [=list/is empty|empty=] [=list=].
 1. [=list/iterate|For each=] |entry| of the [=contribution cache=]:
     1. If |entry|'s [=contribution cache entry/batching scope=] is
         |batchingScope|, [=list/append=] |entry| to |batchEntries|.
+1. If |batchEntries| is [=list/empty=], return.
 1. Let |batchContributions| be a new [=list/is empty|empty=] [=list=].
 1. [=list/iterate|For each=] |entry| of |batchEntries|:
     1. [=list/Remove=] |entry| from the [=contribution cache=].
     1. [=list/Append=] |entry|'s [=contribution cache entry/contribution=] to
         |batchContributions|.
-1. If |batchEntries| is [=list/empty=], return.
 1. Perform the [=PrivateAggregation/report creation and scheduling steps=] with
     |reportingOrigin|, |contextType| and |batchContributions|.
-
-Issue: Highlight exported algorithms more?
 
 Scheduling reports {#scheduling-reports}
 ----------------------------------------
@@ -624,9 +630,10 @@ appropriate):
 </div>
 Second, at the end of the same nested scope, add the following step:
 <div algorithm="shared-storage-run-monkeypatch-2">
-5. When the above [=call=] returns, [=mark a batching scope complete=] given
-    <var ignore>batchingScope</var>, <var ignore>outsideSettings</var>'
-    [=environment settings object/origin=] and "<code>shared-storage</code>".
+5. When the above [=call=] returns, [=process contributions for a batching
+    scope=] given <var ignore>batchingScope</var>,
+    <var ignore>outsideSettings</var>' [=environment settings object/origin=]
+    and "<code>shared-storage</code>".
 
 </div>
 
@@ -640,9 +647,9 @@ appropriate):
 </div>
 Second, at the end of the same nested scope, add the following step:
 <div algorithm="shared-storage-selecturl-monkeypatch-2">
-8. [=Mark a batching scope complete=] given <var ignore>batchingScope</var>,
-    <var ignore>outsideSettings</var>' [=environment settings object/origin=]
-    and "<code>shared-storage</code>".
+8. [=Process contributions for a batching scope=] given
+    <var ignore>batchingScope</var>, <var ignore>outsideSettings</var>'
+    [=environment settings object/origin=] and "<code>shared-storage</code>".
 
 </div>
 
@@ -662,8 +669,8 @@ as appropriate:
         privateAggregation}}'s [=PrivateAggregation/get batching scope steps=]
         to the following algorithm:
         1. Return the [=batching scope=] that is scheduled to be passed to
-            [=mark a batching scope complete=] when the currently executing
-            call returns.
+            [=process contributions for a batching scope=] when the currently
+            executing call returns.
 
             Note: Multiple operation invocations can be in-progress at the same
             time, each with a different batching scope. However, only one can be
@@ -730,8 +737,8 @@ later steps as appropriate:
         contribution=] and then [=append an entry to the contribution cache=].
     1. [=list/iterate|For each=] |origin| → |batchingScope| of
         |batchingScopeMap|:
-        1. [=Mark a batching scope complete=] given |batchingScope|, |origin|
-            and "<code>protected-audience</code>".
+        1. [=Process contributions for a batching scope=] given |batchingScope|,
+            |origin| and "<code>protected-audience</code>".
 
 </div>
 

--- a/spec.bs
+++ b/spec.bs
@@ -282,7 +282,7 @@ Issue: This would ideally be replaced by a more descriptive algorithm in Infra.
 Exported algorithms {#exported-algorithms}
 ------------------------------------------
 
-Note: These algorithms allow other specifications can integrate with this API.
+Note: These algorithms allow other specifications to integrate with this API.
 
 To <dfn algorithm export>append an entry to the contribution cache</dfn> given a
 [=contribution cache entry=] |entry|:

--- a/spec.bs
+++ b/spec.bs
@@ -36,6 +36,8 @@ spec: hr-time; type: dfn; urlPrefix: https://w3c.github.io/hr-time/
     text: moment; url: #dfn-moment
     text: unix epoch; url: #dfn-unix-epoch
     text: wall clock; url: #dfn-wall-clock
+spec: html; type: dfn; urlPrefix: https://tc39.es/ecma262/
+    text: call; url: sec-call
 </pre>
 
 <pre class=link-defaults>
@@ -612,24 +614,72 @@ partial interface SharedStorageWorkletGlobalScope {
 };
 </xmp>
 
-At the start of each invocation of a Shared Storage operation (i.e. a call to
-`run()` or to `selectURL()`), create a new [=batching scope=] and associate it
-with that invocation.
+The {{WindowSharedStorage}}'s {{WindowSharedStorage/run()}} method steps are
+modified in two ways. First, add the following step in the nested scope just
+after "Let |operation| be |operationMap|[|name|]." (renumbering later steps as
+appropriate):
+<div algorithm="shared-storage-run-monkeypatch-1">
+2. Let <var ignore>batchingScope</var> be a new [=batching scope=].
 
-When a {{PrivateAggregation}} object is exposed on a
-{{SharedStorageWorkletGlobalScope}}, its [=PrivateAggregation/get batching scope
-steps=] should be left default until the `addModule()` execution is complete. At
-that point, it should be set to the following algorithm:
-1. Return the [=batching scope=] associated with the currently executing
-    operation invocation in |scope|.
+</div>
+Second, at the end of the same nested scope, add the following step:
+<div algorithm="shared-storage-run-monkeypatch-2">
+5. When the above [=call=] returns, [=mark a batching scope complete=] given
+    <var ignore>batchingScope</var>, <var ignore>outsideSettings</var>'
+    [=environment settings object/origin=] and "<code>shared-storage</code>".
 
-Note: Multiple operation invocations can be in-progress at the same time, each
-with a different batching scope. However, only one can be currently executing.
+</div>
 
-When an operation invocation completes, [=mark a batching scope complete=] given
-the associated [=batching scope=], the global scope's [=relevant settings
-object=]'s [=environment settings object/origin=] and
-"<code>shared-storage</code>".
+The {{WindowSharedStorage}}'s {{WindowSharedStorage/selectURL()}} method steps
+are modified in two ways. First, add the following step in the nested scope just
+after "Let |operation| be |operationMap|[|name|]." (renumbering later steps as
+appropriate):
+<div algorithm="shared-storage-selecturl-monkeypatch-1">
+2. Let <var ignore>batchingScope</var> be a new [=batching scope=].
+
+</div>
+Second, at the end of the same nested scope, add the following step:
+<div algorithm="shared-storage-selecturl-monkeypatch-2">
+8. [=Mark a batching scope complete=] given <var ignore>batchingScope</var>,
+    <var ignore>outsideSettings</var>' [=environment settings object/origin=]
+    and "<code>shared-storage</code>".
+
+</div>
+
+Issue: Once <a href="https://github.com/wicg/shared-storage/issues/88">
+    shared-storage/88</a> is resolved, align the above monkeypatches with how
+    `keepAlive` is handled at operation completion.
+
+The {{Worklet/addModule()}} steps are modified to add a new step just before
+the final step ("Return <var ignore>promise</var>."), renumbering the last step
+as appropriate:
+<div algorithm="shared-storage-addmodule-monkeypatch">
+7. If |this| is a {{SharedStorageWorklet}}, [=upon fulfillment=] of |promise| or
+    [=upon rejection=] of |promise|, run the following steps:
+    1. Let |globalScopes| be |this|'s [=Worklet/global scopes=].
+    1. [=Assert=]: |globalScopes|' [=list/size=] equals 1.
+    1. Set |globalScopes|[0]'s {{SharedStorageWorkletGlobalScope/
+        privateAggregation}}'s [=PrivateAggregation/get batching scope steps=]
+        to the following algorithm:
+        1. Return the [=batching scope=] that is scheduled to be passed to
+            [=mark a batching scope complete=] when the currently executing
+            call returns.
+
+            Note: Multiple operation invocations can be in-progress at the same
+            time, each with a different batching scope. However, only one can be
+            currently executing.
+
+</div>
+
+Issue: Once <a href="https://github.com/wicg/shared-storage/issues/89">
+    shared-storage/89</a> is resolved, align the above monkeypatch with how
+    access to `sharedStorage` is prevented in
+    {{SharedStorageWorkletGlobalScope}}s until {{Worklet/addModule()}}'s initial
+    execution is complete.
+
+Note: This extends Shared Storage's existing {{Worklet/addModule()}}
+    <a href="https://wicg.github.io/shared-storage/#worklet-monkey-patch">
+    monkeypatch</a>.
 
 Protected Audience API monkeypatches {#protected-audience-api-monkeypatches}
 ============================================================================
@@ -662,32 +712,53 @@ partial interface PrivateAggregation {
 
 Issue: Do we want to align naming with implementation?
 
-At the start of each Protected Audience auction (i.e. a call to
-`runAdAuction()`), create a new [=batching scope=] for each unique origin
-participating in the auction (including both bidders and the seller).
+The {{Navigator/runAdAuction()}} method steps are modified to add the following
+steps after step 6 ("Let <var ignore>p</var> be [=a new promise=]"), renumbering
+later steps as appropriate:
+<div algorithm="protected-audience-runadauction-monkeypatch">
+7. Let |batchingScopeMap| be a new [=map/is empty|empty=] [=map=].
+1. [=list/iterate|For each=] |bidderOrigin| of |auctionConfig|'s
+    <a spec="turtledove" for="auction config">interest group buyers</a>:
+    1. [=map/Set=] |batchingScopeMap|[|bidderOrigin|] to a new [=batching
+        scope=].
+1. Let |sellerOrigin| be |auctionConfig|'s
+    <a spec="turtledove" for="auction config">seller</a>.
+1. [=map/Set=] |batchingScopeMap|[|sellerOrigin|] to a new [=batching scope=].
+1. [=Upon fulfillment=] of |p| or [=upon rejection=] of |p|, run the following
+    steps:
+    1. TODO: Take onEvent contributions from its cache, run [=fill in the
+        contribution=] and then [=append an entry to the contribution cache=].
+    1. [=list/iterate|For each=] |origin| → |batchingScope| of
+        |batchingScopeMap|:
+        1. [=Mark a batching scope complete=] given |batchingScope|, |origin|
+            and "<code>protected-audience</code>".
 
-When a {{PrivateAggregation}} object is exposed on a
-{{InterestGroupScriptRunnerGlobalScope}}, its [=PrivateAggregation/get batching
-scope steps=] should be left default until the `addModule()` execution is
-complete. At that point, it should be set to the following algorithm:
-1. Return the [=batching scope=] associated with the auction and the |scope|'s
-    [=relevant settings object=]'s [=environment settings object/origin=].
-
-When an auction completes, perform the following steps:
-1. TODO: Take onEvent contributions from its cache, run [=fill in the
-    contribution=] and then [=append an entry to the contribution cache=].
-1. Let |allOrigins| be a [=list=] of all the unique [=origins=] that
-    participated in the auction (including both bidders and the seller).
-1. [=list/iterate|For each=] |origin| of |allOrigins|:
-    1. [=Mark a batching scope complete=] given the [=batching scope=]
-        associated with the auction and |origin|, |origin| and
-        "<code>protected-audience</code>".
+</div>
 
 Issue: How to handle fenced frame-triggered contributions and other
     event-triggered contributions.
 
 Issue: Need to handle `auctionReportBuyers` and `auctionReportBuyerKeys` here or
     in the Protected Audience API spec.
+
+The <a spec="turtledove">evaluate a script</a> steps are modified to add the
+following steps after step 11 ("If <var ignore>evaluationStatus</var> is an
+[=ECMAScript/abrupt completion=]..."), renumbering later steps as appropriate:
+<div algorithm="protected-audience-evaluate-a-script-monkeypatch">
+12. Set <var ignore>global</var>'s {{InterestGroupScriptRunnerGlobalScope/
+    privateAggregation}}'s [=PrivateAggregation/get batching scope steps=] to
+    the following algorithm:
+    1. Return the [=batching scope=] associated with the auction and the
+        <var ignore>scope</var>'s [=relevant settings object=]'s [=environment
+        settings object/origin=].
+
+</div>
+
+Issue: Once <a href="https://github.com/wicg/turtledove/issues/615">
+    protected-audience/615</a> is resolved, align the above monkeypatch with how
+    access to other functions is prevented in
+    {{InterestGroupScriptRunnerGlobalScope}}s until the script's initial
+    execution is complete.
 
 <div algorithm>
 The <dfn method for="PrivateAggregation">contributeToHistogramOnEvent(DOMString

--- a/spec.bs
+++ b/spec.bs
@@ -200,7 +200,8 @@ A batching scope is a <a spec=HTML>unique internal value</a> that identifies
 which {{PAHistogramContribution}}s should be sent in the same [=aggregatable
 report=].
 
-Issue: Unique internal value is not an exported definition. See infra/583.
+Issue: Unique internal value is not an exported definition. See
+    <a href="https://github.com/whatwg/infra/issues/583">infra/583</a>.
 
 <h4 dfn-type=dfn>Contribution cache entry</h4>
 A contribution cache entry is a [=struct=] with the following items:
@@ -271,7 +272,7 @@ To <dfn>serialize an integer</dfn>, represent it as a [=string=] of the shortest
 possible decimal number.
 
 Issue: This would ideally be replaced by a more descriptive algorithm in Infra.
-    See infra/201
+    See <a href="https://github.com/whatwg/infra/issues/201">infra/201</a>.
 
 To <dfn algorithm export>append an entry to the contribution cache</dfn> given a
 [=contribution cache entry=] |entry|:

--- a/spec.bs
+++ b/spec.bs
@@ -133,7 +133,8 @@ are:
     [=PrivateAggregation/get batching scope steps=].
 1. If |batchingScopeSteps| is null, throw a new {{DOMException}} with name
     "`NotAllowedError`".
-    Note: This indicates the API is not yet available.
+    Note: This indicates the API is not yet available, for example, because the
+        the initial execution of the script after loading is not complete.
 
 1. Let |entry| be a new [=contribution cache entry=] with the items:
     : [=contribution cache entry/contribution=]
@@ -157,8 +158,9 @@ global scope.
 Additionally, each global scope should set the [=PrivateAggregation/get batching
 scope steps=] for the {{PrivateAggregation}} object it exposes to a non-null
 value. The global scope may wait to set the field to indicate that the API is
-not yet available. For any batching scope returned by the [=PrivateAggregation/
-get batching scope steps=], the [=mark a batching scope complete=] steps should
+not yet available, for example, during the initial execution of a script after
+loading. For any batching scope returned by the [=PrivateAggregation/get
+batching scope steps=], the [=mark a batching scope complete=] steps should
 later be performed given that same batching scope, the global scope's [=relevant
 settings object=]'s [=environment settings object/origin=] and some [=context
 type=].

--- a/spec.bs
+++ b/spec.bs
@@ -109,13 +109,6 @@ dictionary PAHistogramContribution {
 };
 </xmp>
 
-Each {{PrivateAggregation}} has a <dfn>contributions cache</dfn>, a [=list=].
-Each item must be either a {{PAHistogramContribution}} or a
-{{PAExtendedHistogramContribution}}.
-
-Note: The steps to process the [=contributions cache=] are defined separately
-    for each [=context type=].
-
 Issue: Do we need to spec enableDebugMode?
 
 Issue: Need to spec Permissions Policy integration.
@@ -130,13 +123,45 @@ are:
     is not in the range [0, 2<sup>128</sup>−1].
 1. Throw {{RangeError}} if |contribution|["{{PAHistogramContribution/value}}"]
     is negative.
-1. [=list/Append=] |contribution| to the [=contributions cache=].
+1. Let |batchingScope| be the result of [=determining the batching scope=] given
+    the global scope.
+1. If |batchingScope| is null, throw a new {{DOMException}} with name
+    "`NotAllowedError`".
+1. Let |entry| be a new [=contribution cache entry=] with the items:
+    : [=contribution cache entry/contribution=]
+    :: |contribution|
+    : [=contribution cache entry/batching scope=]
+    :: The result of [=determining the batching scope=] given the global scope
+
+1. [=Append an entry to the contribution cache=] given |entry|.
 
 Issue: Check that value can actually be zero in the spec pipeline.
 
+Issue(44): Consider accepting an array of contributions.
+
+
+Exposing to global scopes {#exposing}
+=====================================
+
+To expose this API to a global scope, a readonly attribute of type
+{{PrivateAggregation}} named `privateAggregation` should be exposed on the
+global scope.
+
+Additionally, each global scope should define an algorithm for how to
+<dfn algorithm>determine the batching scope</dfn> given the global scope that
+returns a [=batching scope=] or null. For any batching scope returned, the
+[=mark a batching scope complete=] steps should later be performed given that
+same batching scope, the global scope's [=relevant settings object=]'s
+[=environment settings object/origin=] and some [=context type=]. A return value
+of null indicates that the API is not available.
+
+Note: Global scopes with different origins therefore cannot share the same
+batching scope.
 
 Exposing to the Shared Storage API {#shared-storage}
-====================================================
+----------------------------------------------------
+
+Issue(43): This should be moved to the Shared Storage spec.
 
 <xmp class="idl">
 partial interface SharedStorageWorkletGlobalScope {
@@ -144,23 +169,29 @@ partial interface SharedStorageWorkletGlobalScope {
 };
 </xmp>
 
-Immediately after an operation completes, [=process the Shared Storage
-contributions cache=] given the worklet's [=contributions cache=] and the
-worklet's global scope.
+At the start of each invocation of a Shared Storage operation (i.e. a call to
+`run()` or to `selectURL()`), create a new [=batching scope=] and associate it
+with that invocation. To determine the batching scope given a
+{{SharedStorageWorkletGlobalScope}} |scope|:
+1. If there is no currently executing operation invocation, return null.
+1. Otherwise, return the [=batching scope=] associated with the currently
+    executing operation invocation in |scope|.
 
-Issue: How to handle batching different operation invocations properly. This
-    doesn't work for simultaneous operations. Also disallow usage outside an
-    operation.
+Note: Multiple operation invocations can be in-progress at the same time, each
+with a different batching scope. However, only one can be currently executing.
 
-To <dfn>process the Shared Storage contributions cache</dfn> given a [=list=]
-|contributionsCache| and a {{SharedStorageWorkletGlobalScope}} |scope|, perform
-the [=PrivateAggregation/report creation and scheduling steps=] with |scope|'s
-[=relevant settings object=]'s [=environment settings object/origin=],
-"<code>[=context type/shared-storage=]</code>" and |contributionsCache|.
+When an operation invocation completes, [=mark a batching scope complete=] given
+the associated [=batching scope=], the global scope's [=relevant settings
+object=]'s [=environment settings object/origin=] and
+"<code>shared-storage</code>".
 
+Issue: How do we handle overrides without causing bikeshed errors?
 
 Exposing to the Protected Audience API {#protected-audience}
-============================================================
+------------------------------------------------------------
+
+Issue(43): This should be moved to the Protected Audience spec, along with any
+    other Protected Audience-specific details.
 
 <xmp class="idl">
 partial interface InterestGroupScriptRunnerGlobalScope {
@@ -187,12 +218,28 @@ partial interface PrivateAggregation {
 
 Issue: Do we want to align naming with implementation?
 
-Immediately after an auction completes, [=process the Protected Audience
-contributions cache=] given the worklet's [=contributions cache=] and the
-worklet's global scope.
+At the start of each Protected Audience auction (i.e. a call to
+`runAdAuction()`), create a new [=batching scope=] for each unique origin
+participating in the auction (including both bidders and the seller).
 
-Issue: Does Protected Audience API have one global scope per auction or
-    multiple? If multiple, will need to change scope for batching.
+To determine the batching scope given a {{InterestGroupScriptRunnerGlobalScope}}
+|scope|:
+1. If called from the top-level script context (i.e. not inside of
+    `generateBid()`, `scoreAd()`, `reportWin()`, `reportResult()` or functions
+    called from these), return null.
+1. Otherwise, return the [=batching scope=] associated with the auction and the
+    |scope|'s [=relevant settings object=]'s [=environment settings object/
+    origin=].
+
+When an auction completes, perform the following steps:
+1. TODO: Take onEvent contributions from its cache, run [=fill in the
+    contribution=] and then [=append an entry to the contribution cache=].
+1. Let |allOrigins| be a [=list=] of all the unique [=origins=] that
+    participated in the auction (including both bidders and the seller).
+1. [=list/iterate|For each=] |origin| of |allOrigins|:
+    1. [=Mark a batching scope complete=] given the [=batching scope=]
+        associated with the auction and |origin|, |origin| and
+        "<code>protected-audience</code>".
 
 Issue: How to handle fenced frame-triggered contributions and other
     event-triggered contributions.
@@ -214,17 +261,7 @@ Issue: Fill in the rest. (Need to put the contribution in some sort of queue and
     process the queue at some point. Need to decide where the queue should live
     given it has to outlive the auction.)
 
-To <dfn>process the Protected Audience contributions cache</dfn> given a
-[=list=] |contributionsCache| and a {{InterestGroupScriptRunnerGlobalScope}}
-|scope|, perform the following steps:
-1. Let |filledInContributions| be a new [=list/is empty|empty=] [=list=].
-1. [=list/iterate|For each=] |contribution| of |contributionsCache|:
-    1. [=list/Append=] the result of [=filling in the contribution=] given
-        |contribution| to |filledInContributions|.
-1. Perform the [=PrivateAggregation/report creation and scheduling steps=] with
-    |scope|'s [=relevant settings object=]'s [=environment settings object/
-    origin=], "<code>[=context type/fledge=]</code>" and
-    |filledInContributions|.
+Issue(44): Consider accepting an array of contributions.
 
 
 Structures {#structures}
@@ -233,7 +270,23 @@ Structures {#structures}
 General {#general-structures}
 -----------------------------
 
-<h4 dfn-type=dfn>Aggregatable report</h3>
+<h4 dfn-type=dfn>Batching scope</h4>
+A batching scope is a unique internal value that identifies which
+{{PAHistogramContribution}}s should be sent in the same [=aggregatable report=].
+
+Issue: Should unique internal value be a link somewhere? Infra spec?
+
+<h4 dfn-type=dfn>Contribution cache entry</h4>
+A contribution cache entry is a [=struct=] with the following items:
+<dl dfn-for="contribution cache entry">
+: <dfn>contribution</dfn>
+:: A {{PAHistogramContribution}}
+: <dfn>batching scope</dfn>
+:: A [=batching scope=]
+
+</dl>
+
+<h4 dfn-type=dfn>Aggregatable report</h4>
 
 An aggregatable report is a [=struct=] with the following items:
 <dl dfn-for="aggregatable report">
@@ -257,20 +310,9 @@ An aggregatable report is a [=struct=] with the following items:
 Issue: Handle operation types, aggregation coordinators, maybe retries/offline,
     report verification
 
-<h4 dfn-type=dfn>Context type</h3>
-A context type is one of the following:
-<dl dfn-for="context type">
-: "<dfn><code>fledge</code></dfn>"
-:: The global scope's [=global names=] [=list/contains=]
-    {{InterestGroupScriptRunnerGlobalScope}}.
-: "<dfn><code>shared-storage</code></dfn>"
-:: The global scope's [=global names=] [=list/contains=]
-    {{SharedStorageWorklet}}.
-
-</dl>
-
-Issue: Need to update "<code>[=context type/fledge=]</code>" to reflect API name
-    change.
+<h4 dfn-type=dfn>Context type</h4>
+A context type is a [=string=] indicating what kind of global scope the
+{{PrivateAggregation}} object was exposed in.
 
 Protected Audience API-specific {#protected-audience-api-specific-structures}
 -----------------------------------------------------------------------------
@@ -300,6 +342,9 @@ Issue: New enum needed for bid reject reasons.
 Storage {#storage}
 ==================
 
+A user agent holds an <dfn>contribution cache</dfn>, which is a [=list=] of
+[=contribution cache entries=].
+
 A user agent holds an <dfn>aggregatable report cache</dfn>, which is a [=list=]
 of [=aggregatable reports=].
 
@@ -326,6 +371,28 @@ possible decimal number.
 
 Issue: This would ideally be replaced by a more descriptive algorithm in Infra.
     See infra/201
+
+To <dfn algorithm export>append an entry to the contribution cache</dfn> given a
+[=contribution cache entry=] |entry|:
+1. [=list/Append=] |entry| to the [=contribution cache=].
+
+To <dfn algorithm export>mark a batching scope complete</dfn> given a [=batching
+scope=] |batchingScope|, an [=origin=] |reportingOrigin| and a [=context type=]
+|contextType|:
+1. Let |batchEntries| be a new [=list/is empty|empty=] [=list=].
+1. [=list/iterate|For each=] |entry| of the [=contribution cache=]:
+    1. If |entry|'s [=contribution cache entry/batching scope=] is
+        |batchingScope|, [=list/append=] |entry| to |batchEntries|.
+1. Let |batchContributions| be a new [=list/is empty|empty=] [=list=].
+1. [=list/iterate|For each=] |entry| of |batchEntries|:
+    1. [=list/Remove=] |entry| from the [=contribution cache=].
+    1. [=list/Append=] |entry|'s [=contribution cache entry/contribution=] to
+        |batchContributions|.
+1. If |batchEntries| is [=list/empty=], return.
+1. Perform the [=PrivateAggregation/report creation and scheduling steps=] with
+    |reportingOrigin|, |contextType| and |batchContributions|.
+
+Issue: Highlight exported algorithms more?
 
 Scheduling reports {#scheduling-reports}
 ----------------------------------------

--- a/spec.bs
+++ b/spec.bs
@@ -133,8 +133,12 @@ are:
     [=PrivateAggregation/get batching scope steps=].
 1. If |batchingScopeSteps| is null, throw a new {{DOMException}} with name
     "`NotAllowedError`".
+
     Note: This indicates the API is not yet available, for example, because the
         the initial execution of the script after loading is not complete.
+
+    Issue: Consider improving developer ergonomics here (e.g. a way to detect
+        this case).
 
 1. Let |entry| be a new [=contribution cache entry=] with the items:
     : [=contribution cache entry/contribution=]
@@ -192,10 +196,11 @@ General {#general-structures}
 -----------------------------
 
 <h4 dfn-type=dfn>Batching scope</h4>
-A batching scope is a unique internal value that identifies which
-{{PAHistogramContribution}}s should be sent in the same [=aggregatable report=].
+A batching scope is a <a spec=HTML>unique internal value</a> that identifies
+which {{PAHistogramContribution}}s should be sent in the same [=aggregatable
+report=].
 
-Issue: Should unique internal value link somewhere (e.g. infra spec)?
+Issue: Unique internal value is not an exported definition. See infra/583.
 
 <h4 dfn-type=dfn>Contribution cache entry</h4>
 A contribution cache entry is a [=struct=] with the following items:

--- a/spec.bs
+++ b/spec.bs
@@ -113,6 +113,12 @@ Issue: Do we need to spec enableDebugMode?
 
 Issue: Need to spec Permissions Policy integration.
 
+Each {{PrivateAggregation}} object has a field named <dfn
+for="PrivateAggregation">get batching scope steps</dfn> (default null) that is
+either null or an algorithm returning a [=batching scope=].
+
+Note: See [Exposing to global scopes](#exposing) below.
+
 <div algorithm>
 The <dfn method for="PrivateAggregation">
 contributeToHistogram(PAHistogramContribution contribution)</dfn> method steps
@@ -123,15 +129,15 @@ are:
     is not in the range [0, 2<sup>128</sup>−1].
 1. Throw {{RangeError}} if |contribution|["{{PAHistogramContribution/value}}"]
     is negative.
-1. Let |batchingScope| be the result of [=determining the batching scope=] given
-    the global scope.
-1. If |batchingScope| is null, throw a new {{DOMException}} with name
+1. Let |batchingScopeSteps| be the {{PrivateAggregation}} object's
+    [=PrivateAggregation/get batching scope steps=].
+1. If |batchingScopeSteps| is null, throw a new {{DOMException}} with name
     "`NotAllowedError`".
 1. Let |entry| be a new [=contribution cache entry=] with the items:
     : [=contribution cache entry/contribution=]
     :: |contribution|
     : [=contribution cache entry/batching scope=]
-    :: The result of [=determining the batching scope=] given the global scope
+    :: The result of running |batchingScopeSteps|
 
 1. [=Append an entry to the contribution cache=] given |entry|.
 
@@ -147,122 +153,17 @@ To expose this API to a global scope, a readonly attribute of type
 {{PrivateAggregation}} named `privateAggregation` should be exposed on the
 global scope.
 
-Additionally, each global scope should define an algorithm for how to
-<dfn algorithm>determine the batching scope</dfn> given the global scope that
-returns a [=batching scope=] or null. For any batching scope returned, the
-[=mark a batching scope complete=] steps should later be performed given that
-same batching scope, the global scope's [=relevant settings object=]'s
-[=environment settings object/origin=] and some [=context type=]. A return value
-of null indicates that the API is not available.
+Additionally, each global scope should set the [=PrivateAggregation/get batching
+scope steps=] for the {{PrivateAggregation}} object it exposes to a non-null
+value. The global scope may wait to set the field to indicate that the API is
+not yet available. For any batching scope returned by the [=PrivateAggregation/
+get batching scope steps=], the [=mark a batching scope complete=] steps should
+later be performed given that same batching scope, the global scope's [=relevant
+settings object=]'s [=environment settings object/origin=] and some [=context
+type=].
 
-Note: Global scopes with different origins therefore cannot share the same
-batching scope.
-
-Exposing to the Shared Storage API {#shared-storage}
-----------------------------------------------------
-
-Issue(43): This should be moved to the Shared Storage spec.
-
-<xmp class="idl">
-partial interface SharedStorageWorkletGlobalScope {
-  readonly attribute PrivateAggregation privateAggregation;
-};
-</xmp>
-
-At the start of each invocation of a Shared Storage operation (i.e. a call to
-`run()` or to `selectURL()`), create a new [=batching scope=] and associate it
-with that invocation. To determine the batching scope given a
-{{SharedStorageWorkletGlobalScope}} |scope|:
-1. If there is no currently executing operation invocation, return null.
-1. Otherwise, return the [=batching scope=] associated with the currently
-    executing operation invocation in |scope|.
-
-Note: Multiple operation invocations can be in-progress at the same time, each
-with a different batching scope. However, only one can be currently executing.
-
-When an operation invocation completes, [=mark a batching scope complete=] given
-the associated [=batching scope=], the global scope's [=relevant settings
-object=]'s [=environment settings object/origin=] and
-"<code>shared-storage</code>".
-
-Issue: How do we handle overrides without causing bikeshed errors?
-
-Exposing to the Protected Audience API {#protected-audience}
-------------------------------------------------------------
-
-Issue(43): This should be moved to the Protected Audience spec, along with any
-    other Protected Audience-specific details.
-
-<xmp class="idl">
-partial interface InterestGroupScriptRunnerGlobalScope {
-  readonly attribute PrivateAggregation privateAggregation;
-};
-
-dictionary PASignalValue {
-  required DOMString baseValue;
-  double scale;
-  (bigint or long) offset;
-};
-
-dictionary PAExtendedHistogramContribution {
-  required (PASignalValue or bigint) bucket;
-  required (PASignalValue or long) value;
-};
-
-[Exposed=InterestGroupScriptRunnerGlobalScope, SecureContext]
-partial interface PrivateAggregation {
-  undefined contributeToHistogramOnEvent(
-      DOMString event, PAExtendedHistogramContribution contribution);
-};
-</xmp>
-
-Issue: Do we want to align naming with implementation?
-
-At the start of each Protected Audience auction (i.e. a call to
-`runAdAuction()`), create a new [=batching scope=] for each unique origin
-participating in the auction (including both bidders and the seller).
-
-To determine the batching scope given a {{InterestGroupScriptRunnerGlobalScope}}
-|scope|:
-1. If called from the top-level script context (i.e. not inside of
-    `generateBid()`, `scoreAd()`, `reportWin()`, `reportResult()` or functions
-    called from these), return null.
-1. Otherwise, return the [=batching scope=] associated with the auction and the
-    |scope|'s [=relevant settings object=]'s [=environment settings object/
-    origin=].
-
-When an auction completes, perform the following steps:
-1. TODO: Take onEvent contributions from its cache, run [=fill in the
-    contribution=] and then [=append an entry to the contribution cache=].
-1. Let |allOrigins| be a [=list=] of all the unique [=origins=] that
-    participated in the auction (including both bidders and the seller).
-1. [=list/iterate|For each=] |origin| of |allOrigins|:
-    1. [=Mark a batching scope complete=] given the [=batching scope=]
-        associated with the auction and |origin|, |origin| and
-        "<code>protected-audience</code>".
-
-Issue: How to handle fenced frame-triggered contributions and other
-    event-triggered contributions.
-
-Issue: Need to handle `auctionReportBuyers` and `auctionReportBuyerKeys` here or
-    in the Protected Audience API spec.
-
-<div algorithm>
-The <dfn method for="PrivateAggregation">contributeToHistogramOnEvent(DOMString
-event, PAExtendedHistogramContribution contribution)</dfn> method steps are:
-</div>
-
-Issue: Fill in validation. Will need to check offsets are valid and in the right
-    range for the type etc. Also that base values are one of a set.
-
-Issue: Need to document limits on offset, etc.
-
-Issue: Fill in the rest. (Need to put the contribution in some sort of queue and
-    process the queue at some point. Need to decide where the queue should live
-    given it has to outlive the auction.)
-
-Issue(44): Consider accepting an array of contributions.
-
+Note: This last requirement means that global scopes with different origins
+    cannot share the same batching scope.
 
 Structures {#structures}
 ========================
@@ -274,7 +175,7 @@ General {#general-structures}
 A batching scope is a unique internal value that identifies which
 {{PAHistogramContribution}}s should be sent in the same [=aggregatable report=].
 
-Issue: Should unique internal value be a link somewhere? Infra spec?
+Issue: Should unique internal value link somewhere (e.g. infra spec)?
 
 <h4 dfn-type=dfn>Contribution cache entry</h4>
 A contribution cache entry is a [=struct=] with the following items:
@@ -313,31 +214,6 @@ Issue: Handle operation types, aggregation coordinators, maybe retries/offline,
 <h4 dfn-type=dfn>Context type</h4>
 A context type is a [=string=] indicating what kind of global scope the
 {{PrivateAggregation}} object was exposed in.
-
-Protected Audience API-specific {#protected-audience-api-specific-structures}
------------------------------------------------------------------------------
-
-<h4 dfn-type=dfn>Signal base value</h3>
-A signal base value is one of the following:
-<dl dfn-for="signal base value">
-: "<dfn export><code>winning-bid</code></dfn>"
-:: The bid value of the winning bid.
-: "<dfn export><code>highest-scoring-other-bid</code></dfn>"
-:: The bid value of the highest scoring bid that did not win.
-: "<dfn export><code>script-run-time</code></dfn>"
-:: The running time of the script in ms(?).
-: "<dfn export><code>signals-fetch-time</code></dfn>"
-:: The time it took for the signals fetch to complete in ms(?)
-: "<dfn export><code>bid-reject-reason</code></dfn>"
-:: The reason a bid was rejected.
-
-</dl>
-
-Issue: Remove exports when these definitions are used.
-
-Issue: Make sure these definitions match "determine the numeric value" algorithm
-
-Issue: New enum needed for bid reject reasons.
 
 Storage {#storage}
 ==================
@@ -699,9 +575,139 @@ To <dfn>obtain a report's shared info</dfn> given an [=aggregatable report=]
 1. Return the result of [=serializing an infra value to a json string=] given
     |sharedInfo|.
 
+Shared Storage API monkeypatches {#shared-storage-api-monkeypatches}
+====================================================================
 
-Protected Audience API-specific {#protected-audience-api-specific-algorithms}
------------------------------------------------------------------------------
+Issue(43): This should be moved to the Shared Storage spec.
+
+<xmp class="idl">
+partial interface SharedStorageWorkletGlobalScope {
+  readonly attribute PrivateAggregation privateAggregation;
+};
+</xmp>
+
+At the start of each invocation of a Shared Storage operation (i.e. a call to
+`run()` or to `selectURL()`), create a new [=batching scope=] and associate it
+with that invocation.
+
+When a {{PrivateAggregation}} object is exposed on a
+{{SharedStorageWorkletGlobalScope}}, its [=PrivateAggregation/get batching scope
+steps=] should be left default until the `addModule()` execution is complete. At
+that point, it should be set to the following algorithm:
+1. Return the [=batching scope=] associated with the currently executing
+    operation invocation in |scope|.
+
+Note: Multiple operation invocations can be in-progress at the same time, each
+with a different batching scope. However, only one can be currently executing.
+
+When an operation invocation completes, [=mark a batching scope complete=] given
+the associated [=batching scope=], the global scope's [=relevant settings
+object=]'s [=environment settings object/origin=] and
+"<code>shared-storage</code>".
+
+Issue: How do we handle overrides without causing bikeshed errors?
+
+Protected Audience API monkeypatches {#protected-audience-api-monkeypatches}
+============================================================================
+
+Issue(43): This should be moved to the Protected Audience spec, along with any
+    other Protected Audience-specific details.
+
+<xmp class="idl">
+partial interface InterestGroupScriptRunnerGlobalScope {
+  readonly attribute PrivateAggregation privateAggregation;
+};
+
+dictionary PASignalValue {
+  required DOMString baseValue;
+  double scale;
+  (bigint or long) offset;
+};
+
+dictionary PAExtendedHistogramContribution {
+  required (PASignalValue or bigint) bucket;
+  required (PASignalValue or long) value;
+};
+
+[Exposed=InterestGroupScriptRunnerGlobalScope, SecureContext]
+partial interface PrivateAggregation {
+  undefined contributeToHistogramOnEvent(
+      DOMString event, PAExtendedHistogramContribution contribution);
+};
+</xmp>
+
+Issue: Do we want to align naming with implementation?
+
+At the start of each Protected Audience auction (i.e. a call to
+`runAdAuction()`), create a new [=batching scope=] for each unique origin
+participating in the auction (including both bidders and the seller).
+
+When a {{PrivateAggregation}} object is exposed on a
+{{InterestGroupScriptRunnerGlobalScope}}, its [=PrivateAggregation/get batching
+scope steps=] should be left default until the `addModule()` execution is
+complete. At that point, it should be set to the following algorithm:
+1. Return the [=batching scope=] associated with the auction and the |scope|'s
+    [=relevant settings object=]'s [=environment settings object/origin=].
+
+When an auction completes, perform the following steps:
+1. TODO: Take onEvent contributions from its cache, run [=fill in the
+    contribution=] and then [=append an entry to the contribution cache=].
+1. Let |allOrigins| be a [=list=] of all the unique [=origins=] that
+    participated in the auction (including both bidders and the seller).
+1. [=list/iterate|For each=] |origin| of |allOrigins|:
+    1. [=Mark a batching scope complete=] given the [=batching scope=]
+        associated with the auction and |origin|, |origin| and
+        "<code>protected-audience</code>".
+
+Issue: How to handle fenced frame-triggered contributions and other
+    event-triggered contributions.
+
+Issue: Need to handle `auctionReportBuyers` and `auctionReportBuyerKeys` here or
+    in the Protected Audience API spec.
+
+<div algorithm>
+The <dfn method for="PrivateAggregation">contributeToHistogramOnEvent(DOMString
+event, PAExtendedHistogramContribution contribution)</dfn> method steps are:
+</div>
+
+Issue: Fill in validation. Will need to check offsets are valid and in the right
+    range for the type etc. Also that base values are one of a set.
+
+Issue: Need to document limits on offset, etc.
+
+Issue: Fill in the rest. (Need to put the contribution in some sort of queue and
+    process the queue at some point. Need to decide where the queue should live
+    given it has to outlive the auction.)
+
+Issue(44): Consider accepting an array of contributions.
+
+Protected Audience API-specific structures {#protected-audience-api-specific-structures}
+----------------------------------------------------------------------------------------
+
+<h4 dfn-type=dfn>Signal base value</h3>
+A signal base value is one of the following:
+<dl dfn-for="signal base value">
+: "<dfn export><code>winning-bid</code></dfn>"
+:: The bid value of the winning bid.
+: "<dfn export><code>highest-scoring-other-bid</code></dfn>"
+:: The bid value of the highest scoring bid that did not win.
+: "<dfn export><code>script-run-time</code></dfn>"
+:: The running time of the script in ms(?).
+: "<dfn export><code>signals-fetch-time</code></dfn>"
+:: The time it took for the signals fetch to complete in ms(?)
+: "<dfn export><code>bid-reject-reason</code></dfn>"
+:: The reason a bid was rejected.
+
+</dl>
+
+Issue: Remove exports when these definitions are used.
+
+Issue: Make sure these definitions match "determine the numeric value" algorithm
+
+Issue: New enum needed for bid reject reasons.
+
+Protected Audience API-specific algorithms {#protected-audience-api-specific-algorithms}
+----------------------------------------------------------------------------------------
 
 To <dfn>fill in the contribution</dfn> given a |contribution|, perform the
 following steps. They return a {{PAHistogramContribution}}.


### PR DESCRIPTION
Creates new exported algorithms and one algorithm to be overriden. This cl doesn't actually move any content to other specs, but is a step to making that simpler. This change also addresses batching, by defining the batching scopes more completely.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/pull/51.html" title="Last updated on Jun 9, 2023, 7:47 PM UTC (ada0439)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/51/b69953e...ada0439.html" title="Last updated on Jun 9, 2023, 7:47 PM UTC (ada0439)">Diff</a>