### PR TITLE
Spec: remove PrivateAggregation namespacing for algorithms

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -301,15 +301,15 @@ a [=batching scope=] |batchingScope|, an [=origin=] |reportingOrigin| and a
     1. [=list/Remove=] |entry| from the [=contribution cache=].
     1. [=list/Append=] |entry|'s [=contribution cache entry/contribution=] to
         |batchContributions|.
-1. Perform the [=PrivateAggregation/report creation and scheduling steps=] with
-    |reportingOrigin|, |contextType| and |batchContributions|.
+1. Perform the [=report creation and scheduling steps=] with |reportingOrigin|,
+    |contextType| and |batchContributions|.
 
 Scheduling reports {#scheduling-reports}
 ----------------------------------------
 
-To perform the <dfn algorithm for="PrivateAggregation">report creation and
-scheduling steps</dfn> with an [=origin=] |reportingOrigin|, a [=context type=]
-|api| and a [=list=] of {{PAHistogramContribution}}s |contributions|:
+To perform the <dfn algorithm>report creation and scheduling steps</dfn> with an
+[=origin=] |reportingOrigin|, a [=context type=] |api| and a [=list=] of
+{{PAHistogramContribution}}s |contributions|:
 1. [=Assert=]: |reportingOrigin| is a [=potentially trustworthy origin=].
 1. Let |truncatedContributions| be a new [=list/is empty|empty=] [=list=].
 1. If |contributions| has a [=list/size=] greater than [=maximum report
@@ -323,35 +323,33 @@ scheduling steps</dfn> with an [=origin=] |reportingOrigin|, a [=context type=]
     1. [=Assert=]: |contribution|["|value|"] is non-negative.
     1. Add |contribution|["|value|"] to |contributionSum|.
 1. Let |currentWallTime| be the [=current wall time=].
-1. Let |sufficientBudget| be the result of [=PrivateAggregation/consuming budget
-    if permitted=] given |contributionSum|, |reportingOrigin|, |api| and
-    |currentWallTime|.
+1. Let |sufficientBudget| be the result of [=consuming budget if permitted=]
+    given |contributionSum|, |reportingOrigin|, |api| and |currentWallTime|.
 1. If |sufficientBudget| is false, return.
-1. Let |report| be the result of [=PrivateAggregation/obtaining an aggregatable
-    report=] given |reportingOrigin|, |api|, |truncatedContributions| and
-    |currentWallTime|.
+1. Let |report| be the result of [=obtaining an aggregatable report=] given
+    |reportingOrigin|, |api|, |truncatedContributions| and |currentWallTime|.
 1. [=set/Append=] |report| to the user agent's [=aggregatable report cache=].
 
 Issue: Do we need to ensure the reports aren't queued after being sent?
 
 Issue: Do we need to address user settings here at all?
 
-To <dfn algorithm for="PrivateAggregation">consume budget if permitted</dfn>
-given a {{long}} |value|, an [=origin=] <var ignore=''>origin</var>, a [=context
-type=] |api| and a [=moment=] |currentTime|, perform [=implementation-defined=]
-steps. They return a [=boolean=], which indicates whether there is sufficient
-'contribution budget' left to send the requested contribution |value|. This
-budget should be bound to usage over time, e.g. the contribution sum over the
-last 24 hours. The algorithm should assume that the contribution will be sent if
-and only if true is returned, i.e. it should consume the budget in that case.
+To <dfn algorithm>consume budget if permitted</dfn> given a {{long}} |value|, an
+[=origin=] <var ignore=''>origin</var>, a [=context type=] |api| and a
+[=moment=] |currentTime|, perform [=implementation-defined=] steps. They return
+a [=boolean=], which indicates whether there is sufficient 'contribution budget'
+left to send the requested contribution |value|. This budget should be bound to
+usage over time, e.g. the contribution sum over the last 24 hours. The algorithm
+should assume that the contribution will be sent if and only if true is
+returned, i.e. it should consume the budget in that case.
 
-To <dfn for="PrivateAggregation">obtain an aggregatable report</dfn> given an
-[=origin=] |reportingOrigin|, a [=context type=] |api|, a [=list=] of
+To <dfn>obtain an aggregatable report</dfn> given an [=origin=]
+|reportingOrigin|, a [=context type=] |api|, a [=list=] of
 {{PAHistogramContribution}}s |contributions| and a [=moment=] |currentTime|,
 perform the following steps. They return an [=aggregatable report=].
 1. [=Assert=]: |reportingOrigin| is a [=potentially trustworthy origin=].
-1. Let |reportTime| be the result of running [=PrivateAggregation/obtain a
-    report delivery time=] given |currentTime|.
+1. Let |reportTime| be the result of running [=obtain a report delivery time=]
+    given |currentTime|.
 1. Let |report| be a new [=aggregatable report=] with the items:
     : [=aggregatable report/reporting origin=]
     :: |reportingOrigin|
@@ -369,11 +367,8 @@ perform the following steps. They return an [=aggregatable report=].
     :: false
 1. Return |report|.
 
-Issue: Go through and be consistent about namespacing of algorithms.
-
-To <dfn algorithm for="PrivateAggregation">obtain a report delivery time</dfn>
-given a [=moment=] |currentTime|, perform the following steps. They return a
-[=moment=].
+To <dfn algorithm>obtain a report delivery time</dfn> given a [=moment=]
+|currentTime|, perform the following steps. They return a [=moment=].
 1. Let |r| be a random double between 0 (inclusive) and 1 (exclusive) with
     uniform probability.
 1. Return |currentTime| + [=minimum report delay=] + |r| * [=randomized report


### PR DESCRIPTION
Removes the unnecessary for="PrivateAggregation" namespacing for algorithms. Methods on the PrivateAggregation object retain their namespacing


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/pull/54.html" title="Last updated on Jun 9, 2023, 7:56 PM UTC (cb1b416)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/54/3d32307...cb1b416.html" title="Last updated on Jun 9, 2023, 7:56 PM UTC (cb1b416)">Diff</a>