### PR TITLE
Spec: Remove redundant "empty" when constructing lists and maps

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -427,7 +427,7 @@ scope=] |debugScope|:
 To <dfn algorithm export>process contributions for a batching scope</dfn> given
 a [=batching scope=] |batchingScope|, an [=origin=] |reportingOrigin| and a
 [=context type=] |contextType|:
-1. Let |batchEntries| be a new [=list/is empty|empty=] [=list=].
+1. Let |batchEntries| be a new [=list=].
 1. [=list/iterate|For each=] |entry| of the [=contribution cache=]:
     1. If |entry|'s [=contribution cache entry/batching scope=] is
         |batchingScope|:
@@ -449,14 +449,13 @@ a [=batching scope=] |batchingScope|, an [=origin=] |reportingOrigin| and a
     Note: If a context ID was specified, a report is always sent. See
         [Protecting against leaks via the number of
         reports](#protecting-against-leaks-via-the-number-of-reports).
-1. Let |batchedContributions| be a new [=map/is empty|empty=] [=ordered map=].
+1. Let |batchedContributions| be a new [=ordered map=].
 1. [=list/iterate|For each=] |entry| of |batchEntries|:
     1. [=list/Remove=] |entry| from the [=contribution cache=].
     1. Let |debugDetails| be |entry|'s [=contribution cache entry/debug
         details=].
     1. If |batchedContributions|[|debugDetails|] does not [=map/exist=]:
-        1. [=map/Set=] |batchedContributions|[|debugDetails|] to a new [=list/is
-            empty|empty=] [=list=].
+        1. [=map/Set=] |batchedContributions|[|debugDetails|] to a new [=list=].
     1. [=list/Append=] |entry|'s [=contribution cache entry/contribution=] to
         |batchedContributions|[|debugDetails|].
 1. If |batchedContributions| [=map/is empty=]:
@@ -479,9 +478,6 @@ a [=batching scope=] |batchingScope|, an [=origin=] |reportingOrigin| and a
 Note: These steps break up the contributions based on their [=debug details=] as
     each report can only have one set of metadata.
 
-Issue: Here and elsewhere, no need to specify that a new [=list=] or [=map=] is
-    empty.
-
 To <dfn algorithm export>set the context ID for a batching scope</dfn> given
 a [=string=] |contextId| and a [=batching scope=] |batchingScope|:
 
@@ -497,7 +493,7 @@ To perform the <dfn algorithm>report creation and scheduling steps</dfn> with an
 {{PAHistogramContribution}}s |contributions|, a [=debug details=] |debugDetails|
 and a [=string=] or null |contextId|:
 1. [=Assert=]: |reportingOrigin| is a [=potentially trustworthy origin=].
-1. Let |truncatedContributions| be a new [=list/is empty|empty=] [=list=].
+1. Let |truncatedContributions| be a new [=list=].
 1. If |contributions| has a [=list/size=] greater than [=maximum report
     contributions=]:
     1. [=set/For each=] |n| of [=the exclusive range|the range=] 0 to [=maximum
@@ -721,7 +717,7 @@ report=] |report|, perform the following steps. They return a [=list=] of
 1. Let |encryptedPayload| be the result of [=encrypting the payload=] given
     |plaintextPayload|, |pkR| and |sharedInfo|.
 1. If |encryptedPayload| is an error, return |encryptedPayload|.
-1. Let |aggregationServicePayloads| be a new [=list/is empty|empty=] [=list=].
+1. Let |aggregationServicePayloads| be a new [=list=].
 1. Let |aggregationServicePayload| be an [=ordered map=] of the following
     key/value pairs:
     : "`key_id`"
@@ -747,7 +743,7 @@ Note: The user agent is encouraged to enforce regular key rotation. If there are
 
 To <dfn>obtain the plaintext payload</dfn> given an [=aggregatable report=]
     |report|, perform the following steps. They return a [=byte sequence=].
-1. Let |payloadData| be a new [=list/is empty|empty=] [=list=].
+1. Let |payloadData| be a new [=list=].
 1. [=list/iterate|For each=] |contribution| of |report|'s [=aggregatable report/
     contributions=]:
     1. Let |contributionData| be an [=ordered map=] of the following key/value
@@ -1046,7 +1042,7 @@ event, PAExtendedHistogramContribution contribution)</dfn> method steps are:
 1. Let |cacheMap| be |auctionConfig|'s [=auction config/per-bid or seller on
     event contribution cache=].
 1. If |cacheMap|[|ig|] does not [=map/exist=], [=map/set=] |cacheMap|[|ig|] to
-    a new [=map/is empty|empty=] [=on event contribution cache=].
+    a new [=on event contribution cache=].
 1. Let |onEventContributionCache| be |cacheMap|[|ig|].
 1. If |onEventContributionCache|[|event|] does not [=map/exist=], set
     |onEventContributionCache|[|event|] to a new [=list=].
@@ -1067,8 +1063,7 @@ Extend the <a spec="turtledove">auction config</a> [=struct=] to add new fields:
 
     Note: a null key represents the seller.
 : <dfn>batching scope map</dfn>
-:: A [=map=] from [=origin=] to [=batching scope=], initially
-    [=map/is empty|empty=].
+:: A [=map=] from [=origin=] to [=batching scope=].
 
     Note: Does not include [=batching scopes=] for contributions conditional on
         non-reserved events.


### PR DESCRIPTION
"new empty map" -> "new map" and "new empty list" -> "new list"