### PR TITLE
Spec: Link "throw" to definition

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -148,14 +148,15 @@ contributeToHistogram(PAHistogramContribution contribution)</dfn> method steps
 are:
 </div>
 
-1. If [=this=]'s [=PrivateAggregation/allowed to use=] is false, throw an
-    "{{InvalidAccessError}}" {{DOMException}}.
+1. If [=this=]'s [=PrivateAggregation/allowed to use=] is false, [=exception/
+    throw=] an "{{InvalidAccessError}}" {{DOMException}}.
 1. If |contribution|["{{PAHistogramContribution/bucket}}"] is not in the range
-    [0, 2<sup>128</sup>−1], throw a {{RangeError}}.
-1. If |contribution|["{{PAHistogramContribution/value}}"] is negative, throw a
-    {{RangeError}}.
+    [0, 2<sup>128</sup>−1], [=exception/throw=] a {{RangeError}}.
+1. If |contribution|["{{PAHistogramContribution/value}}"] is negative,
+    [=exception/throw=] a {{RangeError}}.
 1. Let |scopingDetails| be [=this=]'s [=PrivateAggregation/scoping details=].
-1. If |scopingDetails| is null, throw a "{{NotAllowedError}}" {{DOMException}}.
+1. If |scopingDetails| is null, [=exception/throw=] a "{{NotAllowedError}}"
+    {{DOMException}}.
 
     Note: This indicates the API is not yet available, for example, because the
         initial execution of the script after loading is not complete.
@@ -185,22 +186,24 @@ The <dfn method for="PrivateAggregation">
 enableDebugMode(optional PADebugModeOptions options)</dfn> method steps are:
 </div>
 
-1. If [=this=]'s [=PrivateAggregation/allowed to use=] is false, throw an
-    "{{InvalidAccessError}}" {{DOMException}}.
+1. If [=this=]'s [=PrivateAggregation/allowed to use=] is false, [=exception/
+    throw=] an "{{InvalidAccessError}}" {{DOMException}}.
 1. Let |scopingDetails| be [=this=]'s [=PrivateAggregation/scoping details=].
-1. If |scopingDetails| is null, throw a "{{NotAllowedError}}" {{DOMException}}.
+1. If |scopingDetails| is null, [=exception/throw=] a "{{NotAllowedError}}"
+    {{DOMException}}.
 1. Let |debugScope| be the result of running |scopingDetails|' [=scoping
     details/get debug scope steps=].
 1. Let |debugScopeMap| be the [=debug scope map=].
-1. If |debugScopeMap|[|debugScope|] [=map/exists=], throw a "{{DataError}}"
-    {{DOMException}}.
+1. If |debugScopeMap|[|debugScope|] [=map/exists=], [=exception/throw=] a
+    "{{DataError}}" {{DOMException}}.
 
     Note: This would occur if `enableDebugMode()` has already been run for this
         [=debug scope=].
 1. Let |debugKey| be null.
 1. If |options| was given:
     1. If |options|["{{PADebugModeOptions/debugKey}}] is not in the range
-        [0, 2<sup>64</sup>−1], throw a "{{DataError}}" {{DOMException}}.
+        [0, 2<sup>64</sup>−1], [=exception/throw=] a "{{DataError}}"
+        {{DOMException}}.
     1. Set |debugKey| to |options|["{{PADebugModeOptions/debugKey}}].
 1. Let |debugDetails| be a new [=debug details=] with the items:
     : [=debug details/enabled=]
@@ -1000,10 +1003,11 @@ Issue: Do we want to align naming with implementation?
 The <dfn method for="PrivateAggregation">contributeToHistogramOnEvent(DOMString
 event, PAExtendedHistogramContribution contribution)</dfn> method steps are:
 </div>
-1. If [=this=]'s [=PrivateAggregation/allowed to use=] is false, throw an
-    "{{InvalidAccessError}}" {{DOMException}}.
+1. If [=this=]'s [=PrivateAggregation/allowed to use=] is false, [=exception/
+    throw=] an "{{InvalidAccessError}}" {{DOMException}}.
 1. Let |scopingDetails| be [=this=]'s [=PrivateAggregation/scoping details=].
-1. If |scopingDetails| is null, throw a "{{NotAllowedError}}" {{DOMException}}.
+1. If |scopingDetails| is null, [=exception/throw=] a "{{NotAllowedError}}"
+    {{DOMException}}.
 1. If |event| [=string/starts with=] "`reserved.`" and « "`reserved.always`",
     "`reserved.loss`", "`reserved.win`" » does not [=list/contain=] |event|,
     return.
@@ -1013,15 +1017,15 @@ event, PAExtendedHistogramContribution contribution)</dfn> method steps are:
 1. Let |bucket| be |contribution|["{{PAExtendedHistogramContribution/bucket}}"].
 1. If |bucket| is a {{PASignalValue}}:
     1. If |bucket|["{{PASignalValue/baseValue}}"] is not a valid [=signal base
-        value=], throw a {{TypeError}}.
-    1. If |bucket|["{{PASignalValue/offset}}"] is not a {{bigint}}, throw a
-        {{TypeError}}.
+        value=], [=exception/throw=] a {{TypeError}}.
+    1. If |bucket|["{{PASignalValue/offset}}"] is not a {{bigint}}, [=exception/
+        throw=] a {{TypeError}}.
 1. Let |value| be |contribution|["{{PAExtendedHistogramContribution/value}}"].
 1. If |value| is a {{PASignalValue}}:
     1. If |value|["{{PASignalValue/baseValue}}"] is not a valid [=signal base
-        value=], throw a {{TypeError}}.
-    1. If |value|["{{PASignalValue/offset}}"] is a {{bigint}}, throw a
-        {{TypeError}}.
+        value=], [=exception/throw=] a {{TypeError}}.
+    1. If |value|["{{PASignalValue/offset}}"] is a {{bigint}}, [=exception/
+        throw=] a {{TypeError}}.
 1. Let |batchingScope| be null.
 1. If |event| [=string/starts with=] "`reserved.`", set |batchingScope| to the
     result of running |scopingDetails|' [=scoping details/get batching scope


### PR DESCRIPTION
Adds hyperlinks when throwing an exception.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/pull/76.html" title="Last updated on Jun 23, 2023, 7:35 PM UTC (243dcde)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/76/b4028f7...243dcde.html" title="Last updated on Jun 23, 2023, 7:35 PM UTC (243dcde)">Diff</a>