### PR TITLE
Spec: Switch to patcg-id UD

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -3,7 +3,7 @@ Title: Private Aggregation API
 Shortname: private-aggregation-api
 Level: 1
 Status: UD
-Group: patcg-ig
+Group: patcg-id
 Repository: patcg-individual-drafts/private-aggregation-api
 URL: https://patcg-individual-drafts.github.io/private-aggregation-api
 Editor: Alexander Turner, Google https://www.google.com, alexmt@chromium.org

--- a/spec.bs
+++ b/spec.bs
@@ -2,8 +2,8 @@
 Title: Private Aggregation API
 Shortname: private-aggregation-api
 Level: 1
-Status: w3c/CG-DRAFT
-Group: patcg
+Status: UD
+Group: patcg-ig
 Repository: patcg-individual-drafts/private-aggregation-api
 URL: https://patcg-individual-drafts.github.io/private-aggregation-api
 Editor: Alexander Turner, Google https://www.google.com, alexmt@chromium.org


### PR DESCRIPTION
Per discussion in https://github.com/speced/bikeshed-boilerplate/pull/43 and #59, we should update the spec's group from patcg to patcg-id and the status to UD.

This is blocked on the bikeshed-boilerplate PR linked above as well as https://github.com/speced/bikeshed/pull/2628.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/pull/86.html" title="Last updated on Aug 18, 2023, 3:31 PM UTC (fd6254e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/86/ef50c13...fd6254e.html" title="Last updated on Aug 18, 2023, 3:31 PM UTC (fd6254e)">Diff</a>