### PR TITLE
Spec: removes commented out metadata

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -13,8 +13,6 @@ Abstract: A generic API for measuring aggregate, cross-site data in a privacy
     data is encrypted, ensuring it can only be processed by an <em>aggregation
     service</em>. During processing, this service will add noise and impose
     limits on how many queries can be performed.
-
-<!--- Warning: Not Ready -->
 Markup Shorthands: markdown on
 Complain About: accidental-2119 on, missing-example-ids on
 Assume Explicit For: on


### PR DESCRIPTION
This is causing some bikeshed errors now.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 15, 2023, 9:17 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fpatcg-individual-drafts%2Fprivate-aggregation-api%2Fb5842634d397fdadf000f3ca6ff2b5847ffb7965%2Fspec.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
FATAL ERROR: Unknown metadata key "&lt;!--- Warning". Prefix custom keys with "!".
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20patcg-individual-drafts/private-aggregation-api%2388.)._
</details>
