### PR TITLE
Spec: Allow debug mode to be disabled arbitrarily by the user agent.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -204,6 +204,10 @@ enableDebugMode(optional PADebugModeOptions options)</dfn> method steps are:
     : [=debug details/key=]
     :: |debugKey|
 
+1. Optionally, set |debugDetails| to a new [=debug details=].
+
+    Note: This allows the user agent to make debug mode unavailable globally or
+        just for certain callers.
 1. [=map/Set=] |debugScopeMap|[|debugScope|] to |debugDetails|.
 
 Issue: Ensure errors are of an appropriate type, e.g. {{InvalidAccessError}} is
@@ -436,6 +440,7 @@ To <dfn algorithm export>get a debug details</dfn> given a [=debug scope=]
 1. Let |debugScopeMap| be the [=debug scope map=].
 1. [=Assert=]: |debugScopeMap|[|debugScope|] [=map/exists=].
 1. Return |debugScopeMap|[|debugScope|].
+    Issue: This should return a default when the scope does not exist.
 
 To <dfn algorithm export>mark a debug scope complete</dfn> given a [=debug
 scope=] |debugScope|:

--- a/spec.bs
+++ b/spec.bs
@@ -439,8 +439,9 @@ To <dfn algorithm export>get a debug details</dfn> given a [=debug scope=]
 |debugScope|:
 1. Let |debugScopeMap| be the [=debug scope map=].
 1. [=Assert=]: |debugScopeMap|[|debugScope|] [=map/exists=].
-1. Return |debugScopeMap|[|debugScope|].
+
     Issue: This should return a default when the scope does not exist.
+1. Return |debugScopeMap|[|debugScope|].
 
 To <dfn algorithm export>mark a debug scope complete</dfn> given a [=debug
 scope=] |debugScope|:


### PR DESCRIPTION
Adds logic that allows for debug mode to be disabled even if enableDebugMode() is called. This addresses issue #57. See also the corresponding explainer change: #93.

As a drive-by, adds an issue for an assert that is currently hit.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/pull/90.html" title="Last updated on Sep 21, 2023, 6:32 PM UTC (8f3888c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/90/cf92221...8f3888c.html" title="Last updated on Sep 21, 2023, 6:32 PM UTC (8f3888c)">Diff</a>