### PR TITLE
Clarify when debug mode is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,10 @@ debugging functionality on these reports.
 
 This data will only be available in a transitional phase while third-party
 cookies are available and are already capable of user tracking. The debug mode
-will be disabled if third-party cookies are disabled/deprecated.
+will only be enabled for contexts that are able to access third-party cookies.
+That is, it will be disabled if third-party cookies are disabled/deprecated
+generally or for a particular site/context; note that this also means debug
+mode will automatically become deprecated when third-party cookies are.
 
 #### Enabling
 

--- a/README.md
+++ b/README.md
@@ -301,7 +301,8 @@ cookies are available and are already capable of user tracking. The debug mode
 will only be enabled for contexts that are able to access third-party cookies.
 That is, it will be disabled if third-party cookies are disabled/deprecated
 generally or for a particular site/context; note that this also means debug
-mode will automatically become deprecated when third-party cookies are.
+mode will automatically become deprecated when third-party cookies are
+deprecated.
 
 #### Enabling
 


### PR DESCRIPTION
Per issue #57, we tie debug mode to third-party cookie eligibility. See also the related spec change in #90.