### PR TITLE
Still send deterministic report when budget exhausted

### DIFF
--- a/report_verification.md
+++ b/report_verification.md
@@ -120,7 +120,8 @@ report would have a variable number of contributions embedded (see [batching
 proposal](https://github.com/patcg-individual-drafts/private-aggregation-api#reducing-volume-by-batching)).
 To avoid leaking the number of contributions, we will need to
 [pad](https://github.com/patcg-individual-drafts/private-aggregation-api#padding)
-the encrypted payload.
+the encrypted payload. Additionally, if a context has run out of budget, a
+report should still be sent (containing no contributions).
 
 #### Allows retrospective filtering
 


### PR DESCRIPTION
When a context ID is set, a report should be sent even if budget is exhausted to avoid leaking information about how much budget has been used.

See also the spec change: #91.