### PR TITLE
Spec: Fix a broken debug scope assert

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -436,12 +436,11 @@ To <dfn algorithm export>append an entry to the contribution cache</dfn> given a
 1. [=list/Append=] |entry| to the [=contribution cache=].
 
 To <dfn algorithm export>get a debug details</dfn> given a [=debug scope=]
-|debugScope|:
+|debugScope|, perform the following steps. They return a [=debug details=].
 1. Let |debugScopeMap| be the [=debug scope map=].
-1. [=Assert=]: |debugScopeMap|[|debugScope|] [=map/exists=].
-
-    Issue: This should return a default when the scope does not exist.
-1. Return |debugScopeMap|[|debugScope|].
+1. If |debugScopeMap|[|debugScope|] [=map/exists=], return
+    |debugScopeMap|[|debugScope|].
+1. Otherwise, return a new [=debug details=].
 
 To <dfn algorithm export>mark a debug scope complete</dfn> given a [=debug
 scope=] |debugScope|:


### PR DESCRIPTION
Instead of asserting that a debug scope exists, we should return a default value to match the implementation.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/pull/96.html" title="Last updated on Sep 26, 2023, 9:07 PM UTC (abe2579)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/96/43a7bef...abe2579.html" title="Last updated on Sep 26, 2023, 9:07 PM UTC (abe2579)">Diff</a>