### PR TITLE
Spec: Pad the payload with null contributions

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -794,16 +794,21 @@ To <dfn>obtain the plaintext payload</dfn> given an [=aggregatable report=]
     |report|, perform the following steps. They return a [=byte sequence=].
 1. Let |payloadData| be a new [=list=].
 1. Let |contributions| be |report|'s [=aggregatable report/contributions=].
-1. If |contributions| [=list/is empty=]:
+1. [=Assert=]: |contributions|' [=list/size=] is not greater than [=maximum
+    report contributions=].
+1. [=iteration/While=] |contributions|' [=list/size=] is less than [=maximum
+    report contributions=]:
     1. Let |nullContribution| be a new {{PAHistogramContribution}} with the
         items:
         : {{PAHistogramContribution/bucket}}
         :: 0
         : {{PAHistogramContribution/value}}
         :: 0
-    1. Set |contributions| to « |nullContribution| ».
+    1. [=list/Append=] |nullContribution| to |contributions|.
 
-    Issue(56): Replace with more generic padding.
+    Note: This padding protects against the number of contributions being leaked
+        through the encrypted payload size, see discussion
+        [below](#protecting-against-leaks-via-payload-size).
 1. [=list/iterate|For each=] |contribution| of |report|'s [=aggregatable report/
     contributions=]:
     1. Let |contributionData| be an [=ordered map=] of the following key/value
@@ -1744,10 +1749,7 @@ count.
 
 The length of the payload could additionally expose some cross-site information,
 namely how many contributions are included. To protect against this, the payload
-will be padded in the future.
-
-Issue(56): Pad the payload to avoid this risk.
-
+is padded to a fixed number of contributions.
 ### Temporary debugging mechanism ### {#temporary-debugging-mechanism}
 
 The <code>{{PrivateAggregation/enableDebugMode()}}</code> method allows for many


### PR DESCRIPTION
Ensures that the payload always has a fixed number of contributions by adding (0,0) contributions.

See #56 for more discussion and #95 for the corresponding spec change.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/pull/98.html" title="Last updated on Sep 26, 2023, 9:16 PM UTC (b5bd90d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/98/a02082b...b5bd90d.html" title="Last updated on Sep 26, 2023, 9:16 PM UTC (b5bd90d)">Diff</a>