### PR TITLE
Spec: Reduce delay when a context ID is set

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -614,16 +614,14 @@ To <dfn algorithm>obtain a report delivery time</dfn> given a [=moment=]
 |currentTime| and a [=moment=] or null |timeout|, perform the following steps.
 They return a [=moment=].
 
-1. Let |reportTriggeredTime| be |currentTime|.
-1. If |timeout| is not null, set |reportTriggeredTime| to |timeout|.
-    Issue(80): Reduce the delay when a |timeout| is provided, i.e. when a
-        context ID is set.
+1. If |timeout| is not null:
+    1. Return |timeout|.
 1. If [=automation local testing mode enabled=] is true, return
-    |reportTriggeredTime|.
+    |currentTime|.
 1. Let |r| be a random double between 0 (inclusive) and 1 (exclusive) with
     uniform probability.
-1. Return |reportTriggeredTime| + [=minimum report delay=] + |r| * [=randomized
-    report delay=].
+1. Return |currentTime| + [=minimum report delay=] + |r| * [=randomized report
+    delay=].
 
 Sending reports {#sending-reports}
 ----------------------------------


### PR DESCRIPTION
Changes the report time for reports with a context ID to the Shared Storage timeout (see PR #102), i.e. without any randomized delay.

See issue #80 and the corresponding explainer change #100.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/pull/103.html" title="Last updated on Sep 26, 2023, 9:11 PM UTC (506ae39)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/103/0ca85d9...506ae39.html" title="Last updated on Sep 26, 2023, 9:11 PM UTC (506ae39)">Diff</a>