### PR TITLE
Spec: Add aggregation_coordinator_origin to serialized report

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -739,6 +739,11 @@ error.
 1. If |aggregationServicePayloads| is an error, return
     |aggregationServicePayloads|.
 1. Let |data| be an [=ordered map=] of the following key/value pairs:
+    : "`aggregation_coordinator_origin`"
+    :: An [=implementation-defined=] [=origin=], [=serialization of an
+        origin|serialized=].
+
+        Issue(78): Replace with the chosen (or default) aggregation coordinator.
     : "`aggregation_service_payloads`"
     :: |aggregationServicePayloads|
     : "`shared_info`"


### PR DESCRIPTION
This is a temporary change to reflect the launching of aggregation coordinator selection for Attribution Reporting (which adds this identifier to all aggregatable reports, given shared code). This will be replaced by a more complete spec change that allows for aggregation coordinator selection for Private Aggregation.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/pull/105.html" title="Last updated on Oct 4, 2023, 4:55 PM UTC (05f1003)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/105/813a62d...05f1003.html" title="Last updated on Oct 4, 2023, 4:55 PM UTC (05f1003)">Diff</a>