### PR TITLE
Align enableDebugMode() semantics in explainer with spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,9 @@ privateAggregation.enableDebugMode();
 The browser can optionally apply debug mode to reports requested earlier in that
 context.
 
+This javascript function can only be called once per context. Any subsequent
+calls will throw an exception.
+
 #### Debug keys
 To allow sites to associate reports with the contexts that triggered them, we
 also allow setting 64-bit unsigned integer debug keys. These keys are passed as
@@ -332,9 +335,6 @@ an optional field to the javascript call, for example:
 ```
 privateAggregation.enableDebugMode({debugKey: 1234n});
 ```
-
-This javascript function can only be called once per context. Any subsequent
-calls will be ignored.
 
 #### Duplicate debug report
 


### PR DESCRIPTION
The spec defines [method steps for enableDebugMode()](https://patcg-individual-drafts.github.io/private-aggregation-api/#dom-privateaggregation-enabledebugmode). These steps indicate that the method should throw a `DataError` exception when it has already been called in the current scope.