### PR TITLE
Add requiredSellerCapabilities check when processing auctionReportBuyers

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -2053,9 +2053,9 @@ an <a spec="turtledove">auction config</a> |auctionConfig| and a
             interest group set</a> whose
             <a spec="turtledove" for="interest group">owner</a> is
             |buyerOrigin|:
-            1. If [=turtledove/check if required seller capabilities are
-                permitted=] given |auctionConfig| and |ig| is false,
-                [=iteration/continue=]
+            1. If <a spec="turtledove">check if required seller capabilities are
+                permitted</a> given |auctionConfig| and |ig| is false,
+                [=iteration/continue=].
             1. If seller capabilities don't allow this reporting, [=iteration/
                 continue=].
 

--- a/spec.bs
+++ b/spec.bs
@@ -2053,6 +2053,9 @@ an <a spec="turtledove">auction config</a> |auctionConfig| and a
             interest group set</a> whose
             <a spec="turtledove" for="interest group">owner</a> is
             |buyerOrigin|:
+            1. If [=turtledove/check if required seller capabilities are
+                permitted=] given |auctionConfig| and |ig| is false,
+                [=iteration/continue=]
             1. If seller capabilities don't allow this reporting, [=iteration/
                 continue=].
 


### PR DESCRIPTION
...to avoid generating auctionReportBuyers style contributions for buyers/ interest groups that got filtered out due to failing requiredSellerCapabilities check.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/morlovich/private-aggregation-api/pull/134.html" title="Last updated on Jun 4, 2024, 5:41 PM UTC (bfe077d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/134/a321c7c...morlovich:bfe077d.html" title="Last updated on Jun 4, 2024, 5:41 PM UTC (bfe077d)">Diff</a>