### PR TITLE
Describe per-calling-API contribution count limits in explainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Author: Alex Turner (alexmt@chromium.org)
     - [Duplicate debug report](#duplicate-debug-report)
   - [Reducing volume by batching](#reducing-volume-by-batching)
     - [Batching scope](#batching-scope)
-    - [Contributions limit](#contributions-limit)
+    - [Limiting the number of contributions per report](#limiting-the-number-of-contributions-per-report)
     - [Padding](#padding)
   - [Aggregation coordinator choice](#aggregation-coordinator-choice)
 - [Privacy and security](#privacy-and-security)
@@ -380,21 +380,25 @@ One consideration in the short term is that these calls may have different
 associated [debug modes or keys](#temporary-debugging-mechanism). In this case,
 only calls sharing those details should be batched together.
 
-#### Contributions limit
+#### Limiting the number of contributions per report
 
 We will also need a limit on the number of contributions within a single report.
 In the case that too many contributions are specified with a ‘batching scope’,
-we should truncate them to the limit.
-
-However, to reduce the impact of this limit, we will pre-aggregate (i.e. merge)
-any contributions that have the same bucket and [filtering
+we should truncate them to the limit. To reduce the impact of this limit, we
+will merge any contributions that have the same bucket and [filtering
 ID](https://github.com/patcg-individual-drafts/private-aggregation-api/blob/main/flexible_filtering.md#proposal-filtering-id-in-the-encrypted-payload)
 before truncation.
 
-If necessary, we could instead split the contributions back into multiple
-reports, each respecting the limit.
+This limit may vary by caller. In particular, Protected Audience reports may
+benefit from a higher limit more than Shared Storage reports.
 
-Strawman limit: 20 contributions per report.
+More complex designs that enable callers to configure custom limits are also
+possible, but require further analysis (see [issue #81]).
+
+[issue #81]: https://github.com/patcg-individual-drafts/private-aggregation-api/issues/81
+
+Our implementation plan is to set the limit at 20 contributions per report for
+Shared Storage and 100 contributions per report for Protected Audience.
 
 #### Padding
 


### PR DESCRIPTION
This PR corresponds to
  * "*Increase default report size for Protected Audience callers*" in <https://github.com/patcg-individual-drafts/private-aggregation-api/issues/81#issuecomment-2091524214>.
  * The spec change in #150

@alexmturner PTAL!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dmcardle/private-aggregation-api/pull/138.html" title="Last updated on Jul 1, 2024, 10:07 PM UTC (075b203)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/138/969c944...dmcardle:075b203.html" title="Last updated on Jul 1, 2024, 10:07 PM UTC (075b203)">Diff</a>