### PR TITLE
[CI] Change preview.yml to validate.yml

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,17 +1,15 @@
-name: Preview
+name: Validate
 on:
   pull_request:
     paths: ["**.bs"]
 jobs:
-  preview:
-    name: Preview
+  main:
+    name: Validate Spec
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: pythagoraskitty/w3c-spec-prod@v1.2
         with:
           TOOLCHAIN: bikeshed
-          DESTINATION: pr-preview/${{ github.ref }}/index.html
           SOURCE: spec.bs
-          GH_PAGES_BRANCH: gh-pages
           BUILD_FAIL_ON: warning


### PR DESCRIPTION
This change converts the "Preview" job into a "Validate" job. It still runs for every PR, but it does not deploy to the gh-pages branch.

Fixes #148


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dmcardle/private-aggregation-api/pull/149.html" title="Last updated on Jul 26, 2024, 3:35 PM UTC (7f5429c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/149/11c6711...dmcardle:7f5429c.html" title="Last updated on Jul 26, 2024, 3:35 PM UTC (7f5429c)">Diff</a>