### PR TITLE
Spec: Fix minor type issue in consume budget if permitted

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -697,8 +697,8 @@ null |timeout|:
     |currentWallTime|.
 1. [=set/Append=] |report| to the user agent's [=aggregatable report cache=].
 
-To <dfn algorithm>consume budget if permitted</dfn> given a {{long}} |value|, an
-[=origin=] <var ignore=''>origin</var>, a [=context type=] |api| and a
+To <dfn algorithm>consume budget if permitted</dfn> given an integer |value|,
+an [=origin=] <var ignore=''>origin</var>, a [=context type=] |api| and a
 [=moment=] |currentTime|, perform [=implementation-defined=] steps. They return
 a [=boolean=], which indicates whether there is sufficient 'contribution budget'
 left to send the requested contribution |value|. This budget should be bound to

--- a/spec.bs
+++ b/spec.bs
@@ -701,7 +701,8 @@ To <dfn algorithm>consume budget if permitted</dfn> given an integer |value|,
 an [=origin=] <var ignore=''>origin</var>, a [=context type=] |api| and a
 [=moment=] |currentTime|, perform [=implementation-defined=] steps. They return
 a [=boolean=], which indicates whether there is sufficient 'contribution budget'
-left to send the requested contribution |value|. This budget should be bound to
+left to send the requested contribution |value| (or multiple contributions with
+a sum of values equal to |value|). This budget should be bound to
 usage over time, e.g. the contribution sum over the last 24 hours. The algorithm
 should assume that the contribution will be sent if and only if true is
 returned, i.e. it should consume the budget in that case. If |value| is zero,


### PR DESCRIPTION
The algorithm takes a long when it should just take an integer (as the sum of many longs may not fit in a long).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/pull/152.html" title="Last updated on Aug 1, 2024, 6:25 PM UTC (d844e5b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/152/b87549a...d844e5b.html" title="Last updated on Aug 1, 2024, 6:25 PM UTC (d844e5b)">Diff</a>