### PR TITLE
Update explainers for fenced frame privateAggregationConfig restrictions.

### DIFF
--- a/flexible_filtering.md
+++ b/flexible_filtering.md
@@ -202,7 +202,7 @@ Protected Audience bidders as these flows require context IDs to make the scale
 practical; we do not currently plan to expose context IDs to bidders (see the
 [explainer](https://github.com/patcg-individual-drafts/private-aggregation-api/blob/main/report_verification.md#specifying-a-contextual-id-and-each-possible-ig-owner)
 for more discussion). We also do not plan on allowing these fields to be set
-from within fenced frames, as that can be used to exfiltrate information.
+from within fenced frames, as they may have access to cross-site information.
 
 #### Backwards compatibility
 

--- a/flexible_filtering.md
+++ b/flexible_filtering.md
@@ -201,7 +201,8 @@ We do not currently plan to allow the filtering ID bit size to be configured for
 Protected Audience bidders as these flows require context IDs to make the scale
 practical; we do not currently plan to expose context IDs to bidders (see the
 [explainer](https://github.com/patcg-individual-drafts/private-aggregation-api/blob/main/report_verification.md#specifying-a-contextual-id-and-each-possible-ig-owner)
-for more discussion).
+for more discussion). We also do not plan on allowing these fields to be set
+from within fenced frames, as that can be used to exfiltrate information.
 
 #### Backwards compatibility
 
@@ -301,8 +302,6 @@ to the potential for a large number of null reports, see
 [explainer](https://github.com/patcg-individual-drafts/private-aggregation-api/blob/main/report_verification.md#specifying-a-contextual-id-and-each-possible-ig-owner)
 for more discussion. Identical considerations would apply to this batching ID in
 the `shared_info`; so, we would not allow a batching ID to be set for bidders.
-Note that Protected Audience auction winners could still report using Shared
-Storage in the rendering (fenced) frame.
 
 #### Backwards compatibility
 

--- a/report_verification.md
+++ b/report_verification.md
@@ -525,10 +525,9 @@ significant design and exploration.
 ## Shared Storage in Fenced Frames
 
 When a shared storage operation is run from a fenced frame instead of a
-document, we can’t simply set a contextual ID. Winning ads of FLEDGE auctions
-are required to be _k_-anonymous and can’t communicate with their embedder. So,
-any high entropy contextual ID could not be joined to information outside the
-Fenced Frame.
+document, we can no longer set a contextual ID. Arbitrary information can be put
+into the ID which can be leaked out of the fenced frame, so the ability to set
+it is disabled.
 
 Instead, we propose allowing a Private State Token to be bound to the
 FencedFrameConfig output of a FLEDGE auction. We would reuse the FLEDGE bidder

--- a/report_verification.md
+++ b/report_verification.md
@@ -525,9 +525,9 @@ significant design and exploration.
 ## Shared Storage in Fenced Frames
 
 When a shared storage operation is run from a fenced frame instead of a
-document, we can no longer set a contextual ID. Arbitrary information can be put
-into the ID which can be leaked out of the fenced frame, so the ability to set
-it is disabled.
+document, we can no longer set a contextual ID. Any cross-site information the
+fenced frame has could be embedded in the context ID, so the ability to set it
+is disabled.
 
 Instead, we propose allowing a Private State Token to be bound to the
 FencedFrameConfig output of a FLEDGE auction. We would reuse the FLEDGE bidder


### PR DESCRIPTION
We plan to not allow setting the `contextId` and `filteringIdMaxBytes` from within a fenced frame when calling Shared Storage operations as that can be used to exfiltrate information.

Spec PR: https://github.com/patcg-individual-drafts/private-aggregation-api/pull/151