### PR TITLE
Add Makefile for local dev: building spec, rendering Markdown, etc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ spec.html: spec.bs
 README-with-toc.md: README.md
 	pandoc -f gfm --toc --toc-depth 6 -s $< -o $@
 
-# Rule for generating HTML from Markdown for a limited set of targets. This is a
+# Rule for generating HTML from Markdown for a limited set of targets. This uses
 # GNU Make "static pattern" syntax.
 $(HTML_FROM_MD_TARGETS): %.html : %.md
 	pandoc -f gfm -s $< -o $@

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ clean:
 # out to stale specs. https://speced.github.io/bikeshed/#cli-update
 .PHONY: update
 update:
-	python3 -m bikeshed update
+	bikeshed update
 
 spec.html: spec.bs
-	python3 -m bikeshed --die-on=everything spec $< $@
+	bikeshed --die-on=everything spec $< $@
 
 # Autogenerates a table of contents for the README. This can in turn be rendered
 # as HTML. This is useful for catching mistakes in the README's handwritten TOC.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+# HTML files that are generated from Markdown sources.
+HTML_FROM_MD_TARGETS=README.html README-with-toc.html
+
+.PHONY: all
+all: spec.html $(HTML_FROM_MD_TARGETS)
+
+.PHONY: clean
+clean:
+	-rm spec.html
+	-rm $(HTML_FROM_MD_TARGETS)
+
+# Updates Bikeshed's datafiles. Run this regularly to ensure you're not linking
+# out to stale specs. https://speced.github.io/bikeshed/#cli-update
+.PHONY: update
+update:
+	python3 -m bikeshed update
+
+spec.html: spec.bs
+	python3 -m bikeshed --die-on=everything spec $< $@
+
+# Autogenerates a table of contents for the README. This can in turn be rendered
+# as HTML. This is useful for catching mistakes in the README's handwritten TOC.
+README-with-toc.md: README.md
+	pandoc -f gfm --toc --toc-depth 6 -s $< -o $@
+
+# Rule for generating HTML from Markdown for a limited set of targets. This is a
+# GNU Make "static pattern" syntax.
+$(HTML_FROM_MD_TARGETS): %.html : %.md
+	pandoc -f gfm -s $< -o $@

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ clean:
 	-rm spec.html
 	-rm $(HTML_FROM_MD_TARGETS)
 
-# Updates Bikeshed's datafiles. Run this regularly to ensure you're not linking
-# out to stale specs. https://speced.github.io/bikeshed/#cli-update
+# Updates Bikeshed's datafiles. Bikeshed automatically updates them if they're
+# more than a few days old, but this will ensure you have the latest version.
 .PHONY: update
 update:
 	bikeshed update


### PR DESCRIPTION
Although the spec is already compiled automatically by CI and GitHub renders our Markdown, I still find it useful to automate commands that I frequently use in local development. A Makefile is better than another Markdown file because it's executable!