### PR TITLE
Spec: export obtain the Private Aggregation coordinator algorithm

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -642,6 +642,24 @@ an [=origin=] |origin|, perform the following steps. They return a [=boolean=].
 </div>
 
 <div algorithm>
+To <dfn export>obtain the Private Aggregation coordinator</dfn> given a
+{{USVString}} |originString|, perform the following steps. They return an
+[=aggregation coordinator=] or a {{DOMException}}.
+
+1. Let |url| be the result of running the [=URL parser=] on |originString|.
+1. If |url| is failure or null, return a new {{DOMException}} with name
+    "`SyntaxError`".
+
+    Issue: Consider throwing an error if the path is not empty.
+1. Let |origin| be |url|'s [=url/origin=].
+1. If the result of [=determining if an origin is an aggregation coordinator=]
+    given |origin| is false, return a new {{DOMException}} with name
+    "`DataError`".
+1. Return |origin|.
+
+</div>
+
+<div algorithm>
 To <dfn export>set the aggregation coordinator for a batching scope</dfn> given
 an [=origin=] |origin| and a [=batching scope=] |batchingScope|:
 
@@ -1513,7 +1531,8 @@ following steps at the end of the scope nested under step 5 ("Validate the given
 <div algorithm="protected-audience-joinadig-monkey-patch">
 17. If |group|["{{AuctionAdInterestGroup/privateAggregationConfig}}"]
     [=map/exists=]:
-    1. Let |aggregationCoordinator| be the result of [=obtaining the Private
+    1. Let |aggregationCoordinator| be the result of [=obtain the Private
+        Aggregation coordinator from a PA config|obtaining the Private
         Aggregation coordinator=] given
         |group|["{{AuctionAdInterestGroup/privateAggregationConfig}}"].
     1. If |aggregationCoordinator| is a {{DOMException}}, then
@@ -1610,7 +1629,8 @@ modified to add the following steps just before the last step ("Return
         : [=debug details/key=]
         :: |debugKey|
 1. If |config|["{{AuctionAdConfig/privateAggregationConfig}}"] [=map/exists=]:
-    1. Let |aggregationCoordinator| be the result of [=obtaining the Private
+    1. Let |aggregationCoordinator| be the result of [=obtain the Private
+        Aggregation coordinator from a PA config|obtaining the Private
         Aggregation coordinator=] given
         |config|["{{AuctionAdConfig/privateAggregationConfig}}"].
     1. If |aggregationCoordinator| is a {{DOMException}}, return failure.
@@ -1781,8 +1801,7 @@ steps are modified to add the following case at the end of the "Switch on
     1. If |value|["`aggregationCoordinatorOrigin`"] [=map/exists=]:
         1. If |value|["`aggregationCoordinatorOrigin`"] is not a [=string=],
             jump to the step labeled Abort update.
-        1. Let |aggregationCoordinator| be the result of [=obtain the Private
-            Aggregation coordinator from a string|obtaining the Private
+        1. Let |aggregationCoordinator| be the result of [=obtaining the Private
             Aggregation coordinator=] given
             |value|["`aggregationCoordinatorOrigin`"].
         1. If |aggregationCoordinator| is a {{DOMException}}, jump to the step
@@ -2119,34 +2138,15 @@ They return an [=interest group=] or null:
 </div>
 
 <div algorithm>
-To <dfn>obtain the Private Aggregation coordinator</dfn> given a
+To <dfn lt="obtain the Private Aggregation coordinator from a PA config">obtain
+the Private Aggregation coordinator</dfn> given a
 {{ProtectedAudiencePrivateAggregationConfig}} |config|, perform the following
 steps. They return an [=aggregation coordinator=], null or a {{DOMException}}.
 
 1. If |config|["{{ProtectedAudiencePrivateAggregationConfig/aggregationCoordinatorOrigin}}"]
     does not [=map/exist=], return null.
-1. Return the result of [=obtain the Private Aggregation coordinator from a
-    string|obtaining the Private Aggregation coordinator=] given
+1. Return the result of [=obtaining the Private Aggregation coordinator=] given
     |config|["{{ProtectedAudiencePrivateAggregationConfig/aggregationCoordinatorOrigin}}"].
-
-</div>
-
-<div algorithm>
-To <dfn lt="obtain the Private Aggregation coordinator from a string">obtain the
-Private Aggregation coordinator</dfn> given a {{USVString}} |originString|,
-perform the following steps. They return an [=aggregation coordinator=] or a
-{{DOMException}}.
-
-1. Let |url| be the result of running the [=URL parser=] on |originString|.
-1. If |url| is failure or null, return a new {{DOMException}} with name
-    "`SyntaxError`".
-
-    Issue: Consider throwing an error if the path is not empty.
-1. Let |origin| be |url|'s [=url/origin=].
-1. If the result of [=determining if an origin is an aggregation coordinator=]
-    given |origin| is false, return a new {{DOMException}} with name
-    "`DataError`".
-1. Return |origin|.
 
 </div>
 

--- a/spec.bs
+++ b/spec.bs
@@ -1531,9 +1531,8 @@ following steps at the end of the scope nested under step 5 ("Validate the given
 <div algorithm="protected-audience-joinadig-monkey-patch">
 17. If |group|["{{AuctionAdInterestGroup/privateAggregationConfig}}"]
     [=map/exists=]:
-    1. Let |aggregationCoordinator| be the result of [=obtain the Private
-        Aggregation coordinator from a PA config|obtaining the Private
-        Aggregation coordinator=] given
+    1. Let |aggregationCoordinator| be the result of [=obtaining the coordinator
+        from a Private Aggregation config=] given
         |group|["{{AuctionAdInterestGroup/privateAggregationConfig}}"].
     1. If |aggregationCoordinator| is a {{DOMException}}, then
         [=exception/throw=] |aggregationCoordinator|.
@@ -1629,9 +1628,8 @@ modified to add the following steps just before the last step ("Return
         : [=debug details/key=]
         :: |debugKey|
 1. If |config|["{{AuctionAdConfig/privateAggregationConfig}}"] [=map/exists=]:
-    1. Let |aggregationCoordinator| be the result of [=obtain the Private
-        Aggregation coordinator from a PA config|obtaining the Private
-        Aggregation coordinator=] given
+    1. Let |aggregationCoordinator| be the result of [=obtaining the coordinator
+        from a Private Aggregation config=] given
         |config|["{{AuctionAdConfig/privateAggregationConfig}}"].
     1. If |aggregationCoordinator| is a {{DOMException}}, return failure.
     1. Set <var ignore>auctionConfig</var>'s [=auction config/seller Private
@@ -2138,8 +2136,7 @@ They return an [=interest group=] or null:
 </div>
 
 <div algorithm>
-To <dfn lt="obtain the Private Aggregation coordinator from a PA config">obtain
-the Private Aggregation coordinator</dfn> given a
+To <dfn>obtain the coordinator from a Private Aggregation config</dfn> given a
 {{ProtectedAudiencePrivateAggregationConfig}} |config|, perform the following
 steps. They return an [=aggregation coordinator=], null or a {{DOMException}}.
 


### PR DESCRIPTION
The version that takes a USVString is shared between Protected Audience and Shared Storage, so we can export it. Updates links so that the monkey patched version has a modified linking text as that will be removed from this spec soon.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/pull/163.html" title="Last updated on Oct 17, 2024, 10:04 PM UTC (217a8e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/163/f5cda2b...217a8e2.html" title="Last updated on Oct 17, 2024, 10:04 PM UTC (217a8e2)">Diff</a>