### PR TITLE
Update explainer to ignore site exceptions for debug mode eligibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,8 +360,7 @@ the browser has third-party cookies generally enabled. That is, it will be
 disabled if third-party cookies are disabled/deprecated generally or for a
 particular site/context; note that if third-party cookies are generally
 disabled, but enabled for a particular site, debug mode will not be enabled for
-that site to protect data saved from other sites. This also means debug mode
-will automatically become deprecated when third-party cookies are deprecated.
+that site to protect data saved from other sites.
 
 Though the debug mode is tied to third-party cookie availability, browsers may
 temporarily allow debug mode without third-party cookies in order to support

--- a/README.md
+++ b/README.md
@@ -357,12 +357,11 @@ This data will only be available in a transitional phase while third-party
 cookies are available and are already capable of user tracking. The debug mode
 will only be enabled if the context is able to access third-party cookies and
 the browser has third-party cookies generally enabled. That is, it will be
-disabled if third-party cookies are disabled/deprecated
-generally or for a particular site/context; note that if third-party cookies are
-generally disabled, but enabled for a particular site, debug mode will not be
-enabled for that site to protect data saved from other sites. This also means
-debug mode will automatically become deprecated when third-party cookies are
-deprecated.
+disabled if third-party cookies are disabled/deprecated generally or for a
+particular site/context; note that if third-party cookies are generally
+disabled, but enabled for a particular site, debug mode will not be enabled for
+that site to protect data saved from other sites. This also means debug mode
+will automatically become deprecated when third-party cookies are deprecated.
 
 Though the debug mode is tied to third-party cookie availability, browsers may
 temporarily allow debug mode without third-party cookies in order to support

--- a/README.md
+++ b/README.md
@@ -355,10 +355,13 @@ debugging functionality on these reports.
 
 This data will only be available in a transitional phase while third-party
 cookies are available and are already capable of user tracking. The debug mode
-will only be enabled for contexts that are able to access third-party cookies.
-That is, it will be disabled if third-party cookies are disabled/deprecated
-generally or for a particular site/context; note that this also means debug
-mode will automatically become deprecated when third-party cookies are
+will only be enabled if the context is able to access third-party cookies and
+the browser has third-party cookies generally enabled. That is, it will be
+disabled if third-party cookies are disabled/deprecated
+generally or for a particular site/context; note that if third-party cookies are
+generally disabled, but enabled for a particular site, debug mode will not be
+enabled for that site to protect data saved from other sites. This also means
+debug mode will automatically become deprecated when third-party cookies are
 deprecated.
 
 Though the debug mode is tied to third-party cookie availability, browsers may


### PR DESCRIPTION
Updates the language to only allow debug mode if third-party cookies are generally enabled for a user, ignoring when they are only enabled for a specific site.