### PR TITLE
Spec: don't export / define "remote end steps"

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1236,8 +1236,9 @@ Set local testing mode {#set-local-testing-mode}
     </table>
 </figure>
 
-<div algorithm>
-The <dfn export>remote end steps</dfn> are:
+<div algorithm="remote end steps">
+The <a spec="webdriver2">remote end steps</a> given <var ignore>session</var>,
+[=URL=] <var ignore>variables</var> and |parameters| are:
 
 1. If |parameters| is not a JSON-formatted [[ECMASCRIPT#sec-objects|Object]],
     return a [=error|WebDriver error=] with [=error code=] [=invalid argument=].

--- a/spec.bs
+++ b/spec.bs
@@ -1238,7 +1238,7 @@ Set local testing mode {#set-local-testing-mode}
 
 <div algorithm="remote end steps">
 The <a spec="webdriver2">remote end steps</a> given <var ignore>session</var>,
-[=URL=] <var ignore>variables</var> and |parameters| are:
+<var ignore>URL variables</var> and |parameters| are:
 
 1. If |parameters| is not a JSON-formatted [[ECMASCRIPT#sec-objects|Object]],
     return a [=error|WebDriver error=] with [=error code=] [=invalid argument=].


### PR DESCRIPTION
We should instead link to the original webdriver definition as used in the webdriver spec. Also adds the arguments to the definition.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/pull/174.html" title="Last updated on Feb 28, 2025, 5:12 PM UTC (ed744ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/174/d612b5c...ed744ae.html" title="Last updated on Feb 28, 2025, 5:12 PM UTC (ed744ae)">Diff</a>