### PR TITLE
Do not set request's window

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1289,8 +1289,6 @@ sequence=] |body|:
     ::  |body|
     :   [=request/client=]
     ::  `null`
-    :   [=request/window=]
-    ::  "`no-window`"
     :   [=request/service-workers mode=]
     ::  "`none`"
     :   [=request/initiator=]


### PR DESCRIPTION
Per https://github.com/whatwg/fetch/pull/1823, this concept is going away. After that change, null-client scenarios will automatically do the right thing, and create no user prompts, which aligns with this spec's desired outcome.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/domenic/private-aggregation-api/pull/182.html" title="Last updated on May 13, 2025, 5:05 AM UTC (e5b7945)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/patcg-individual-drafts/private-aggregation-api/182/2041404...domenic:e5b7945.html" title="Last updated on May 13, 2025, 5:05 AM UTC (e5b7945)">Diff</a>